### PR TITLE
fix(nitro): add `NUXT_NO_SSR` when ssr is disabled

### DIFF
--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -115,6 +115,9 @@ export async function setupNitroBridge () {
 
       // Nuxt aliases
       ...nuxt.options.alias
+    },
+    replace: {
+      'process.env.NUXT_NO_SSR': nuxt.options.ssr === false ? true : undefined
     }
   })
 


### PR DESCRIPTION
### 🔗 Linked issue

Addresses issue #30 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves #30 by replacing the process.env.NUXT_NO_SSR in the nitro config based on the user setting in the Nuxt config. Currently there is a runtime error that fails when `ssr: false`.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

