### PR TITLE
fix: revert to static dir

### DIFF
--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -86,7 +86,7 @@ export async function setupNitroBridge () {
         dir: resolve(nuxt.options.buildDir, 'dist/client')
       },
       ...nuxt.options._layers
-        .map(layer => join(layer.config.srcDir, 'public'))
+        .map(layer => join(layer.config.srcDir, layer.config.dir.static))
         .filter(dir => existsSync(dir))
         .map(dir => ({ dir }))
     ],
@@ -151,7 +151,7 @@ export async function setupNitroBridge () {
 
     // Remove public files that have been duplicated into buildAssetsDir
     // TODO: Add option to configure this behaviour in vite
-    const publicDir = join(nuxt.options.srcDir, nuxt.options.dir.public || nuxt.options.dir.static)
+    const publicDir = join(nuxt.options.srcDir, nuxt.options.dir.static)
     let publicFiles: string[] = []
     if (await isDirectory(publicDir)) {
       publicFiles = readDirRecursively(publicDir).map(r => r.replace(publicDir, ''))

--- a/src/vite/vite.ts
+++ b/src/vite/vite.ts
@@ -39,7 +39,7 @@ async function bundle (nuxt: Nuxt, builder: any) {
         base: nuxt.options.dev
           ? joinURL(nuxt.options.app.baseURL, nuxt.options.app.buildAssetsDir)
           : '/__NUXT_BASE__/',
-        publicDir: resolve(nuxt.options.rootDir, nuxt.options.srcDir, nuxt.options.dir.public || nuxt.options.dir.static),
+        publicDir: resolve(nuxt.options.rootDir, nuxt.options.srcDir, nuxt.options.dir.static),
         vue: {
           isProduction: !nuxt.options.dev,
           template: {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #312

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We hard-coded `public` when processing layers. I'm also removing support for `dir.public` as I can't think this would be a useful thing to support when it would be unsupported by the rest of the project.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

