### PR TITLE
fix: dont set currentNuxtInstance null value if not exitst vue instance

### DIFF
--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -71,7 +71,8 @@ export const setNuxtAppInstance = (nuxt: NuxtAppCompat | null) => {
 export function callWithNuxt<T extends (...args: any[]) => any> (nuxt: NuxtAppCompat, setup: T, args?: Parameters<T>) {
   setNuxtAppInstance(nuxt)
   const p: ReturnType<T> = args ? setup(...args as Parameters<T>) : setup()
-  if (process.server) {
+  const vm = getCurrentInstance()
+  if (process.server && vm) {
     // Unset nuxt instance to prevent context-sharing in server-side
     setNuxtAppInstance(null)
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/bridge/issues/319

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description


The application breaks when currentNuxtInstance and getCurrentInstanse are both null. If getCurrentInstance is not defined, do not set currentNuxtInstance to null.
May this solution is not good due to i don't see all workaround, but it works for me. I tested it in middleware, and with pinia, works good.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

