### PR TITLE
fix: write document template to buildDir

### DIFF
--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -389,7 +389,7 @@ async function resolveHandlers (nuxt: Nuxt) {
 async function writeDocumentTemplate (nuxt: Nuxt) {
   // Compile html template
   const src = nuxt.options.appTemplatePath || resolve(nuxt.options.buildDir, 'views/app.template.html')
-  const dst = src.replace(/.html$/, '.mjs').replace('app.template.mjs', 'document.template.mjs')
+  const dst = resolve(nuxt.options.buildDir, 'views/document.template.mjs')
   const contents = nuxt.vfs[src] || await fsp.readFile(src, 'utf-8').catch(() => '')
   if (contents) {
     const compiled = 'export default ' +


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #337

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This resolves an issue with custom app templates where the output was being written there rather than to the build directory.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

