### PR TITLE
fix: update implementation for legacy useFetch for vue 2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "nuxt": "^2",
     "unbuild": "0.7.4",
     "vitest": "^0.17.1",
-    "vue": "^2.7.0",
+    "vue": "^2.7.3",
     "vue-router": "^3"
   },
   "engines": {

--- a/src/runtime/capi.legacy.mjs
+++ b/src/runtime/capi.legacy.mjs
@@ -420,13 +420,17 @@ async function serverPrefetch (vm) {
   const attrs = (vm.$vnode.data.attrs = vm.$vnode.data.attrs || {})
   attrs['data-fetch-key'] = vm._fetchKey
 
-  const data = { ...vm._data }
-  Object.entries(vm.__composition_api_state__.rawBindings).forEach(
-    ([key, val]) => {
-      if (val instanceof Function || val instanceof Promise) { return }
-
-      data[key] = isRef(val) ? val.value : val
-    }
+  const data = Object.fromEntries(
+    Object.entries(vm?._setupProxy || vm?._setupState)
+      .filter(
+        ([_key, val]) =>
+          !(
+            (val && typeof val === 'object' && '_compiled' in val) ||
+            val instanceof Function ||
+            val instanceof Promise
+          )
+      )
+      .map(([key, val]) => [key, isRef(val) ? val.value : val])
   )
 
   // Add to ssrContext for window.__NUXT__.fetch

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -26,7 +26,7 @@ describe('navigate', () => {
 describe('legacy capi', () => {
   it('should continue to work', async () => {
     const html = await $fetch('/legacy-capi/')
-    expect(html).toMatch(/(.*✅){12}/)
+    expect(html).toMatch(/([\s\S]*✅){12}/)
   })
 })
 

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -23,6 +23,13 @@ describe('navigate', () => {
   })
 })
 
+describe('legacy capi', () => {
+  it('should continue to work', async () => {
+    const html = await $fetch('/legacy-capi/')
+    expect(html).toMatch(/(.*✅){12}/)
+  })
+})
+
 describe('errors', () => {
   it('should render a JSON error page', async () => {
     const res = await fetch('/error', {

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -25,8 +25,8 @@ describe('navigate', () => {
 
 describe('legacy capi', () => {
   it('should continue to work', async () => {
-    const html = await $fetch('/legacy-capi/')
-    expect(html).toMatch(/([\s\S]*✅){12}/)
+    const html = await $fetch('/legacy-capi')
+    expect(html).toMatch(/([\s\S]*✅){11}/)
   })
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1234,6 +1234,7 @@
 
 "@nuxt/bridge@link:.":
   version "0.0.0"
+  uid ""
 
 "@nuxt/builder@2.15.8":
   version "2.15.8"
@@ -2391,10 +2392,10 @@
     "@vue/babel-plugin-transform-vue-jsx" "^1.2.1"
     camelcase "^5.0.0"
 
-"@vue/compiler-sfc@2.7.0":
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-2.7.0.tgz#1c203e85290688e10ed3e70b151b9a2f8acab9c1"
-  integrity sha512-hPOI15RsXO1G8aK6FNF93ld9C/D4e/uAJBE59K8NnL8giuKqeVksvamgu4jKhCJ9f9bbUpj5BuSV3sufIx2hmw==
+"@vue/compiler-sfc@2.7.3":
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-2.7.3.tgz#6179ed9787e10c270563e0c1b440955bf9dd8342"
+  integrity sha512-/9SO6KeR1ljo+j4Tdkl9zsFG2yY4NQ9p3GKdPVCU99bmkNkTW8g9Tq8SMEvhOfo+RhBC0PdDAOmibl+N37f5YA==
   dependencies:
     "@babel/parser" "^7.18.4"
     postcss "^8.4.14"
@@ -11691,9 +11692,9 @@ vue-router@^3, vue-router@^3.5.1:
   integrity sha512-x+/DLAJZv2mcQ7glH2oV9ze8uPwcI+H+GgTgTmb5I55bCgY3+vXWIsqbYUzbBSZnwFHEJku4eoaH/x98veyymQ==
 
 vue-server-renderer@^2.6.12:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/vue-server-renderer/-/vue-server-renderer-2.7.0.tgz#140dd0e2f4a99e85633d46b7f89d2cddc4f61859"
-  integrity sha512-9IZIYfbCw+yb7n7NIzByjOlRshllAavWAtpf0hRUxuKqBx95gnkB/za2KavKyo+gUxA3dGx9+syC01f/AyJHGQ==
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/vue-server-renderer/-/vue-server-renderer-2.7.3.tgz#199e3f194b38e5c7b9d68d066a3d5ad2bfead5a4"
+  integrity sha512-KfrLkPR7nZllMmTurw77B7YzfBbDeb5W1ucNsN7C+Tf6MxyYdWaOvjn2DdDLEypW9T0tHoyE7r1g+UMQTmeZrw==
   dependencies:
     chalk "^4.1.2"
     hash-sum "^2.0.0"
@@ -11713,9 +11714,9 @@ vue-style-loader@^4.1.0, vue-style-loader@^4.1.3:
     loader-utils "^1.0.2"
 
 vue-template-compiler@^2.6.12, vue-template-compiler@^2.6.14:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.7.0.tgz#b8ec6b9eb8ca99f20534ac75f0f374d3e48347cf"
-  integrity sha512-b9kKOPNS6J2BVf9skXkKsUwQLP3Bjfb/gG6UoBt3fn4xUVEDko5TSWmkPGW6dSSeAOOvYEMALdouv9caKlTq0Q==
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.7.3.tgz#3ca434a5898ef4eed6122101066e416dae1aefd8"
+  integrity sha512-QKcV4vj9akZ2zSD1+F7tci3aXpRe5DXU3TZ/ZWJPE9gInXD5UoV+Q2PrCaplj4IGIK8JXRHYaSvOXkOn7tg9Og==
   dependencies:
     de-indent "^1.0.2"
     he "^1.2.0"
@@ -11725,12 +11726,12 @@ vue-template-es2015-compiler@^1.9.0:
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
-vue@^2.6.12, vue@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.7.0.tgz#9542552e0460563feff11727949f8964e2501bed"
-  integrity sha512-su25f1hocH+QNkVEqk+Oj7B+mkDIWU70l0YY7nYSJFEs3Z64njXxo65RUXnWH46ooEhKmEWyLdW6HcYn8coNrg==
+vue@^2.6.12, vue@^2.7.3:
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.7.3.tgz#33015b7df481a515d625a2ea20fe01d981085cb7"
+  integrity sha512-7MTirXG7LYJi3r2jeYy7EiXIhEE85uP3kBwSxqwDsvIfy/l7+qR4U6ajw8ji1KoP+wYYg7ZY28TBTf3P3Fa4Nw==
   dependencies:
-    "@vue/compiler-sfc" "2.7.0"
+    "@vue/compiler-sfc" "2.7.3"
     csstype "^3.1.0"
 
 vuex@^3.6.2:


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

this fixes a couple of issues with the Vue 2.7 migration and legacy CAPI support.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

