### PR TITLE
fix: set nuxt context and normalise config as first module

### DIFF
--- a/module.cjs
+++ b/module.cjs
@@ -9,38 +9,38 @@ module.exports.defineNuxtConfig = (config = {}) => {
   // Nuxt kit depends on this flag to check bridge compatibility
   config.bridge = config.bridge ?? true
 
-  if (config.bridge !== false) {
-    // Add new handlers options
-    config.serverHandlers = config.serverHandlers || []
-    config.devServerHandlers = config.devServerHandlers || []
+  if (!config.bridge) { return config }
 
-    config.bridge = config.bridge || {}
-    config.bridge._version = pkg.version
-    if (!config.buildModules) {
-      config.buildModules = []
-    }
-    if (!config.buildModules.find(m => m === '@nuxt/bridge' || m === '@nuxt/bridge-edge')) {
-      // Ensure other modules register their hooks before
-      config.buildModules.push('@nuxt/bridge')
-    }
-    config.buildModules.unshift(async function () {
-      const nuxt = this.nuxt
+  // Add new handlers options
+  config.serverHandlers = config.serverHandlers || []
+  config.devServerHandlers = config.devServerHandlers || []
 
-      const { nuxtCtx } = await import('@nuxt/kit')
-
-      // Allow using kit composables in all modules
-      if (!nuxtCtx.use()) {
-        nuxtCtx.set(nuxt)
-      }
-
-      // Mock _layers for nitro and auto-imports
-      nuxt.options._layers = nuxt.options._layers || [{
-        config: nuxt.options,
-        cwd: nuxt.options.rootDir,
-        configFile: nuxt.options._nuxtConfigFile
-      }]
-    })
+  config.bridge = config.bridge || {}
+  config.bridge._version = pkg.version
+  if (!config.buildModules) {
+    config.buildModules = []
   }
+  if (!config.buildModules.find(m => m === '@nuxt/bridge' || m === '@nuxt/bridge-edge')) {
+    // Ensure other modules register their hooks before
+    config.buildModules.push('@nuxt/bridge')
+  }
+  config.buildModules.unshift(async function () {
+    const nuxt = this.nuxt
+
+    const { nuxtCtx } = await import('@nuxt/kit')
+
+    // Allow using kit composables in all modules
+    if (!nuxtCtx.use()) {
+      nuxtCtx.set(nuxt)
+    }
+
+    // Mock _layers for nitro and auto-imports
+    nuxt.options._layers = nuxt.options._layers || [{
+      config: nuxt.options,
+      cwd: nuxt.options.rootDir,
+      configFile: nuxt.options._nuxtConfigFile
+    }]
+  })
   return config
 }
 

--- a/module.cjs
+++ b/module.cjs
@@ -30,9 +30,10 @@ module.exports.defineNuxtConfig = (config = {}) => {
     const { nuxtCtx } = await import('@nuxt/kit')
 
     // Allow using kit composables in all modules
-    if (!nuxtCtx.use()) {
-      nuxtCtx.set(nuxt)
+    if (nuxtCtx.use()) {
+      nuxtCtx.unset()
     }
+    nuxtCtx.set(nuxt)
 
     // Mock _layers for nitro and auto-imports
     nuxt.options._layers = nuxt.options._layers || [{

--- a/module.cjs
+++ b/module.cjs
@@ -7,7 +7,7 @@ const pkg = require('./package.json')
 
 module.exports.defineNuxtConfig = (config = {}) => {
   // Nuxt kit depends on this flag to check bridge compatibility
-  config.bridge = config.bridge || true
+  config.bridge = config.bridge ?? true
 
   if (config.bridge !== false) {
     // Add new handlers options

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,5 +1,5 @@
 import { createRequire } from 'module'
-import { defineNuxtModule, installModule, checkNuxtCompatibility, nuxtCtx } from '@nuxt/kit'
+import { defineNuxtModule, installModule, checkNuxtCompatibility } from '@nuxt/kit'
 import type { NuxtModule } from '@nuxt/schema'
 import { NuxtCompatibility } from '@nuxt/schema'
 import type { BridgeConfig } from '../types'
@@ -36,22 +36,7 @@ export default defineNuxtModule({
     // Disable if users explicitly set to false
     if ((nuxt.options as any).bridge === false) { return }
 
-    // Nuxt kit depends on this flag to check bridge compatibility
-    (nuxt.options as any).bridge = (nuxt.options as any).bridge || true
-
     const _require = createRequire(import.meta.url)
-
-    // Allow using kit composables in all modules
-    if (!nuxtCtx.use()) {
-      nuxtCtx.set(nuxt)
-    }
-
-    // Mock _layers
-    nuxt.options._layers = nuxt.options._layers || [{
-      config: nuxt.options,
-      cwd: nuxt.options.rootDir,
-      configFile: nuxt.options._nuxtConfigFile
-    }]
 
     if (opts.nitro) {
       nuxt.hook('modules:done', async () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently bridge module runs _last_ (to ensure hooks are registered first) but it should probably normalize the config _first_. This PR adds a stub module to set nuxt context, set `bridge` option, and normalize layers.

Here's an example of a config that now works but previously didn't:

```js
import { defineNuxtConfig } from '@nuxt/bridge'
import { useNuxt } from '@nuxt/kit'

export default defineNuxtConfig({
  buildModules: [
    function () {
      const nuxt = useNuxt()
    }
  ]
})
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

