### PR TITLE
fix: restore vue2-compat alias and de-default export

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -73,9 +73,6 @@ export default defineNuxtModule({
     if (opts.vite) {
       const viteModule = await import('./vite/module').then(r => r.default || r) as NuxtModule
       nuxt.hook('modules:done', () => installModule(viteModule))
-    } else {
-      // with webpack, we need to transpile vue to handle the default/named exports in Vue 2.7
-      nuxt.options.build.transpile.push('vue')
     }
     if (opts.postcss8) {
       await installModule(_require.resolve('@nuxt/postcss8'))

--- a/src/runtime/vue2-bridge.mjs
+++ b/src/runtime/vue2-bridge.mjs
@@ -1,3 +1,15 @@
+import Vue from 'vue'
 export * from 'vue'
 
 export const isFunction = fn => fn instanceof Function
+
+// @ts-ignore
+const defaultVue = Vue.default || Vue
+
+export { defaultVue as default }
+
+// mock for vue-demi
+export const Vue2 = defaultVue
+export const isVue2 = true
+export const isVue3 = false
+export const install = () => {}

--- a/src/vue-compat.ts
+++ b/src/vue-compat.ts
@@ -1,8 +1,9 @@
 import { pathToFileURL } from 'url'
 import MagicString from 'magic-string'
-import { findStaticImports } from 'mlly'
+import { findExports, findStaticImports } from 'mlly'
 import { parseQuery, parseURL } from 'ufo'
 import { createUnplugin } from 'unplugin'
+import escapeRE from 'escape-string-regexp'
 
 export const VueCompat = createUnplugin((opts: { src?: string }) => {
   return {
@@ -28,10 +29,15 @@ export const VueCompat = createUnplugin((opts: { src?: string }) => {
       if (id.includes('vue2-bridge')) { return }
 
       const s = new MagicString(code)
-      const imports = findStaticImports(code).filter(i => i.type === 'static' && vueAliases.includes(i.specifier))
+      const references = [
+        ...findStaticImports(code).filter(i => i.type === 'static' && vueAliases.includes(i.specifier)),
+        ...findExports(code).filter(i => vueAliases.includes(i.specifier))
+      ]
 
-      for (const i of imports) {
-        s.overwrite(i.start, i.end, i.code.replace(`"${i.specifier}"`, `"${opts.src}"`).replace(`'${i.specifier}'`, `'${opts.src}'`))
+      for (const i of references) {
+        const escapedSpecifier = escapeRE(i.specifier)
+        const specifierRE = new RegExp(`"${escapedSpecifier}"|'${escapedSpecifier}'`, 'g')
+        s.overwrite(i.start, i.end, i.code.replace(specifierRE, r => r.replace(i.specifier, opts.src)))
       }
 
       if (s.hasChanged()) {
@@ -45,9 +51,30 @@ export const VueCompat = createUnplugin((opts: { src?: string }) => {
 })
 
 const vueAliases = [
+  // vue
+  'vue',
   // vue 3 helper packages
   '@vue/shared',
   '@vue/reactivity',
   '@vue/runtime-core',
-  '@vue/runtime-dom'
+  '@vue/runtime-dom',
+  // vue-demi
+  'vue-demi',
+  ...[
+    // vue 2 dist files
+    'vue/dist/vue.common.dev',
+    'vue/dist/vue.common',
+    'vue/dist/vue.common.prod',
+    'vue/dist/vue.esm.browser',
+    'vue/dist/vue.esm.browser.min',
+    'vue/dist/vue.esm',
+    'vue/dist/vue',
+    'vue/dist/vue.min',
+    'vue/dist/vue.runtime.common.dev',
+    'vue/dist/vue.runtime.common',
+    'vue/dist/vue.runtime.common.prod',
+    'vue/dist/vue.runtime.esm',
+    'vue/dist/vue.runtime',
+    'vue/dist/vue.runtime.min'
+  ].flatMap(m => [m, `${m}.js`])
 ]


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/bridge/issues/393

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The Vue CJS build does not have named exports, but all functions are present on the default export. This adds some complexity for the webpack build. We can work around this by adding back the vue compat plugin and de-defaulting the Vue import.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

