### PR TITLE
fix: throw error if wrapper isn't used

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -36,7 +36,9 @@ export default defineNuxtModule({
     // Disable if users explicitly set to false
     if ((nuxt.options as any).bridge === false) { return }
 
-    const _require = createRequire(import.meta.url)
+    if (!(nuxt.options as any).bridge._version) {
+      throw new Error('[bridge] Bridge must be enabled by using `defineNuxtConfig` to wrap your Nuxt configuration.')
+    }
 
     if (opts.nitro) {
       nuxt.hook('modules:done', async () => {
@@ -63,6 +65,7 @@ export default defineNuxtModule({
       nuxt.options.build.transpile.push('vue')
     }
     if (opts.postcss8) {
+      const _require = createRequire(import.meta.url)
       await installModule(_require.resolve('@nuxt/postcss8'))
     }
     if (opts.typescript) {


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We are performing normalization in `defineNuxtConfig` (e.g. https://github.com/nuxt/bridge/pull/397) and if users don't use it Bridge won't work as expected.
