### PR TITLE
fix: use named version from 'vue'

### DIFF
--- a/playground/layouts/error.vue
+++ b/playground/layouts/error.vue
@@ -6,6 +6,8 @@
 
 <script>
 export default {
-  props: ['error']
+  props: {
+    error: Error
+  }
 }
 </script>

--- a/src/runtime/app.plugin.mjs
+++ b/src/runtime/app.plugin.mjs
@@ -1,4 +1,4 @@
-import Vue from 'vue'
+import Vue, { version } from 'vue'
 import { createHooks } from 'hookable'
 import { callWithNuxt, setNuxtAppInstance } from '#app'
 
@@ -43,7 +43,7 @@ export default async (ctx, inject) => {
       use (vuePlugin) {
         runOnceWith(vuePlugin, () => vuePlugin.install(this))
       },
-      version: Vue.version
+      version
     },
     provide: inject,
     globalName: 'nuxt',


### PR DESCRIPTION
Kind of a `chore` PR.

### 📚 Description

Resolves both current eslint warnings.
- import `version` from `Vue`
- add type to error prop in playground layout

