### PR TITLE
fix: handle functional `generate.routes`

### DIFF
--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -60,7 +60,7 @@ export async function setupNitroBridge () {
   // Resolve config
   const _nitroConfig = (nuxt.options as any).nitro || {} as NitroConfig
   const routes = Array.isArray(nuxt.options.generate.routes) ? nuxt.options.generate.routes : []
-  const nitroConfig: NitroConfig = defu(_nitroConfig, <NitroConfig>{
+  const nitroConfig: NitroConfig = defu(_nitroConfig, <NitroConfig> {
     rootDir: resolve(nuxt.options.rootDir),
     srcDir: resolve(nuxt.options.srcDir, 'server'),
     dev: nuxt.options.dev,
@@ -142,7 +142,7 @@ export async function setupNitroBridge () {
   // Let nitro handle #build for windows path normalization
   delete nitroConfig.alias['#build']
 
-  if (nuxt.options.generate.routes instanceof Function) {
+  if (nuxt.options.generate.routes instanceof Function && !nuxt.options.dev && !nuxt.options._prepare) {
     console.warn('It is recommended to migrate the `generate.routes` function to the `nitro:config` hook instead. See https://github.com/nuxt/bridge/pull/475.')
     nitroConfig.prerender.routes.push(...await nuxt.options.generate.routes() || [])
   }

--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -174,7 +174,7 @@ export async function setupNitroBridge () {
       for (const file of publicFiles) {
         try {
           fsExtra.rmSync(join(clientDist, file))
-        } catch { }
+        } catch {}
       }
     }
 
@@ -320,7 +320,7 @@ export async function setupNitroBridge () {
       } else {
         const distDir = resolve(nuxt.options.rootDir, 'dist')
         if (!existsSync(distDir)) {
-          await fsp.symlink(nitro.options.output.publicDir, distDir, 'junction').catch(() => { })
+          await fsp.symlink(nitro.options.output.publicDir, distDir, 'junction').catch(() => {})
         }
       }
     }
@@ -419,7 +419,7 @@ function createNuxt2DevServer (nitro: Nitro) {
     renderRoute,
     listen,
     serverMiddlewarePaths () { return [] },
-    ready () { }
+    ready () {}
   }
 }
 

--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -143,7 +143,7 @@ export async function setupNitroBridge () {
   delete nitroConfig.alias['#build']
 
   if (nuxt.options.generate.routes instanceof Function) {
-    console.warn('It is recommended to migrate the `nuxt.generate.routes` function to the `nitro:config` hook instead.')
+    console.warn('It is recommended to migrate the `generate.routes` function to the `nitro:config` hook instead. See https://github.com/nuxt/bridge/pull/475.')
     nitroConfig.prerender.routes.push(...await nuxt.options.generate.routes() || [])
   }
 
@@ -174,7 +174,7 @@ export async function setupNitroBridge () {
       for (const file of publicFiles) {
         try {
           fsExtra.rmSync(join(clientDist, file))
-        } catch {}
+        } catch { }
       }
     }
 
@@ -320,7 +320,7 @@ export async function setupNitroBridge () {
       } else {
         const distDir = resolve(nuxt.options.rootDir, 'dist')
         if (!existsSync(distDir)) {
-          await fsp.symlink(nitro.options.output.publicDir, distDir, 'junction').catch(() => {})
+          await fsp.symlink(nitro.options.output.publicDir, distDir, 'junction').catch(() => { })
         }
       }
     }

--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -59,6 +59,7 @@ export async function setupNitroBridge () {
 
   // Resolve config
   const _nitroConfig = (nuxt.options as any).nitro || {} as NitroConfig
+  const routes = Array.isArray(nuxt.options.generate.routes) ? nuxt.options.generate.routes : []
   const nitroConfig: NitroConfig = defu(_nitroConfig, <NitroConfig>{
     rootDir: resolve(nuxt.options.rootDir),
     srcDir: resolve(nuxt.options.srcDir, 'server'),
@@ -96,7 +97,7 @@ export async function setupNitroBridge () {
     prerender: {
       crawlLinks: nuxt.options._generate ? nuxt.options.generate.crawler : false,
       routes: []
-        .concat(nuxt.options._generate ? ['/', ...nuxt.options.generate.routes] : [])
+        .concat(nuxt.options._generate ? ['/', ...routes] : [])
         .concat(nuxt.options.ssr === false ? ['/', '/200', '/404'] : [])
     },
     externals: {
@@ -140,6 +141,11 @@ export async function setupNitroBridge () {
 
   // Let nitro handle #build for windows path normalization
   delete nitroConfig.alias['#build']
+
+  if (nuxt.options.generate.routes instanceof Function) {
+    console.warn('It is recommended to migrate the `nuxt.generate.routes` function to the `nitro:config` hook instead.')
+    nitroConfig.prerender.routes.push(...await nuxt.options.generate.routes() || [])
+  }
 
   // Extend nitro config with hook
   await nuxt.callHook('nitro:config', nitroConfig)
@@ -331,7 +337,7 @@ export async function setupNitroBridge () {
       }
       const processPages = (pages: NuxtPage[], currentPath = '/') => {
         for (const page of pages) {
-        // Skip dynamic paths
+          // Skip dynamic paths
           if (page.path.includes(':')) { continue }
 
           const path = joinURL(currentPath, page.path)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/bridge/issues/472

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Users who want to programmatically determine what routes should be prerendered should use a hook to do so:

```js
import { defineNuxtConfig } from '@nuxt/bridge'

export default defineNuxtConfig({
  hooks: {
    async 'nitro:config' (config) {
      const routes = await getRoutes()
      config.prerender.routes.push(...routes)
    }
  }
})
```

In the mean time, for backward compatibility, we can call the `generate.routes` function.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

