### PR TITLE
fix(nitro): default to nitro generator and use resolved nitro routes

### DIFF
--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -306,7 +306,7 @@ export async function setupNitroBridge () {
 
       // Invokve classic generation behaviour with --classic CLI argument
 
-      const useClassicGeneration = process.argv.includes('--classic') || !(nuxt.options as any).bridge.nitroGenerator
+      const useClassicGeneration = process.argv.includes('--classic') || (nuxt.options as any).bridge.nitroGenerator === false
       if (useClassicGeneration && nuxt.options._generate) {
         const { Generator } = (await tryImportModule('@nuxt/generator-edge')) || (await tryImportModule('@nuxt/generator'))
         const generator = new Generator(nuxt)
@@ -328,12 +328,11 @@ export async function setupNitroBridge () {
   })
 
   // Prerender all non-dynamic page routes when generating app
-  nuxt.options.nitro = nuxt.options.nitro || {}
   if (!nuxt.options.dev && nuxt.options._generate) {
     const routes = new Set<string>()
     nuxt.hook('build:extendRoutes', (pages) => {
       routes.clear()
-      for (const path of nuxt.options.nitro.prerender?.routes || []) {
+      for (const path of nitro.options.prerender?.routes || []) {
         routes.add(path)
       }
       const processPages = (pages: NuxtPage[], currentPath = '/') => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves  #490

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Although marking `nitroGenerator` as true by default, we were not actually checking the resolved options. This PR also updates the route generation to be based off nitro's prerender options, not the nuxt ones.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

