### PR TITLE
fix: apply runtimeConfig proxy directly to ctx.config

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -101,6 +101,9 @@ export async function setupAppBridge (_options: any) {
     }
   })
 
+  // Normalize runtimeConfig with a proxy
+  addPlugin({ src: resolve(distDir, 'runtime/config.plugin.mjs') })
+
   addPlugin({
     src: resolve(distDir, 'runtime/error.plugin.server.mjs'),
     mode: 'server'

--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -27,24 +27,8 @@ export const useRuntimeConfig = () => {
   if (nuxtApp._config) {
     return nuxtApp._config as RuntimeConfig
   }
-  const config = reactive(nuxtApp.$config)
-  nuxtApp._config = new Proxy(config, {
-    get (target, prop) {
-      if (prop === 'public') {
-        return target.public
-      }
-      return target[prop] ?? target.public[prop]
-    },
-    set (target, prop, value) {
-      if (prop === 'public' || prop === 'app') {
-        return false // Throws TypeError
-      }
-      target[prop] = value
-      target.public[prop] = value
-      return true
-    }
-  })
 
+  nuxtApp._config = reactive(nuxtApp.$config)
   return nuxtApp._config as RuntimeConfig
 }
 

--- a/src/runtime/config.plugin.mjs
+++ b/src/runtime/config.plugin.mjs
@@ -1,0 +1,21 @@
+export default (ctx) => {
+  const config = ctx.$config
+  ctx.$config = new Proxy(config, {
+    get (target, prop) {
+      if (prop === 'public') {
+        return target.public
+      }
+      return target[prop] ?? target.public?.[prop]
+    },
+    set (target, prop, value) {
+      if (prop === 'public' || prop === 'app') {
+        return false // Throws TypeError
+      }
+      target[prop] = value
+      if ('public' in target) {
+        target.public[prop] = value
+      }
+      return true
+    }
+  })
+}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #458

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a plugin to normalize `$config` with a Proxy, moving it from the composable `useRuntimeConfig` into the app itself, which means that usage from `ctx.$config` within plugins works as expected for user plugins.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

