### PR TITLE
fix: normalize config before module-injected plugins

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -13,6 +13,13 @@ export default defineNuxtConfig({
       }
     }
   ],
+  modules: [
+    function () {
+      this.nuxt.options.plugins.unshift({
+        src: '~/plugins/config'
+      })
+    }
+  ],
   buildDir: process.env.NITRO_BUILD_DIR,
   plugins: ['~/plugins/setup.js'],
   nitro: {

--- a/playground/pages/runtime-config.vue
+++ b/playground/pages/runtime-config.vue
@@ -4,6 +4,19 @@ const serverRuntimeConfig = useState('server-runtime-config', () => config)
 const clientRuntimeConfig = process.client ? config : {}
 
 console.log('Config compatibility', config.myValue, config.secretKey)
+if (process.server && config.secretKey !== 'nuxt') {
+  throw new Error('secret key not accessible')
+}
+if (config.myValue !== 123) {
+  throw new Error('public key not accessible on root')
+}
+const pluginConfig = useNuxtApp().$modulePlugin
+if (process.client && pluginConfig !== '{"myValue":123,"publicMyValue":123}') {
+  throw new Error('config not available in plugin')
+}
+if (process.server && pluginConfig !== '{"secretKey":"nuxt","myValue":123,"publicMyValue":123}') {
+  throw new Error('config not available in plugin')
+}
 </script>
 
 <template>

--- a/playground/plugins/config.js
+++ b/playground/plugins/config.js
@@ -1,0 +1,7 @@
+export default ({ $config }, inject) => {
+  inject('modulePlugin', JSON.stringify({
+    secretKey: $config.secretKey,
+    myValue: $config.myValue,
+    publicMyValue: $config.public?.myValue
+  }))
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -102,7 +102,9 @@ export async function setupAppBridge (_options: any) {
   })
 
   // Normalize runtimeConfig with a proxy
-  addPlugin({ src: resolve(distDir, 'runtime/config.plugin.mjs') })
+  nuxt.hook('modules:done', () => {
+    nuxt.options.plugins.unshift({ src: resolve(distDir, 'runtime/config.plugin.mjs') })
+  })
 
   addPlugin({
     src: resolve(distDir, 'runtime/error.plugin.server.mjs'),

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -131,6 +131,30 @@ describe('dynamic paths', () => {
     }
   })
 
+  it('should set runtime config', async () => {
+    const html = await $fetch('/runtime-config')
+    expect(html.match(/<pre>([\s\S]*)<\/pre>/)?.[0].replace(/&quot;/g, '"')).toMatchInlineSnapshot(`
+      "<pre>{
+        \\"app\\": {
+          \\"baseURL\\": \\"./\\",
+          \\"basePath\\": \\"/\\",
+          \\"assetsPath\\": \\"/_nuxt/\\",
+          \\"cdnURL\\": \\"\\",
+          \\"buildAssetsDir\\": \\"/_nuxt/\\"
+        },
+        \\"nitro\\": {
+          \\"routes\\": {},
+          \\"envPrefix\\": \\"NUXT_\\"
+        },
+        \\"public\\": {
+          \\"myValue\\": 123
+        },
+        \\"secretKey\\": \\"nuxt\\"
+      }</pre>"
+    `)
+    await expectNoClientErrors('/runtime-config')
+  })
+
   it('should use baseURL when redirecting', async () => {
     process.env.NUXT_APP_BUILD_ASSETS_DIR = '/_other/'
     process.env.NUXT_APP_BASE_URL = '/foo/'


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

previously, module-injected plugins did not have access to normalized config. cc: @aldarund

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

