### PR TITLE
fix: hook up watchers to nuxt 3 hooks

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -28,6 +28,15 @@ export async function setupAppBridge (_options: any) {
     })
   }
 
+  nuxt.hook('builder:prepared', (builder) => {
+    nuxt.hook('build:done', () => {
+      for (const name of ['app', 'files', 'custom']) {
+        builder.watchers[name].on('all', (event, path) => nuxt.callHook('builder:watch', event, path))
+      }
+    })
+    nuxt.hook('builder:generateApp', () => builder.generateRoutesAndFiles())
+  })
+
   // Transpile core vue libraries
   // TODO: resolve in vercel/nft
   nuxt.options.build.transpile.push('vuex')

--- a/src/imports/module.ts
+++ b/src/imports/module.ts
@@ -99,6 +99,7 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
     })
 
     // Watch composables/ directory
+    nuxt.options.build.watch.push(...composablesDirs)
     nuxt.hook('builder:watch', async (_, path) => {
       const _resolved = resolve(nuxt.options.srcDir, path)
       if (composablesDirs.find(dir => _resolved.startsWith(dir))) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/framework/issues/2215

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This allows us to invalidate virtual templates when the nuxt 2 watcher detects changes, such as wehn composables are added to the app, and adds compatibility with any future kit plugin to invalidate templates..

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

