### PR TITLE
fix: provide nuxt `useRoute` and `useRouter` composables

### DIFF
--- a/src/imports/presets.ts
+++ b/src/imports/presets.ts
@@ -33,6 +33,8 @@ export const appPreset = defineUnimportPreset({
     'useCookie',
     'useRequestHeaders',
     'useRequestEvent',
+    'useRouter',
+    'useRoute',
     'defineNuxtRouteMiddleware',
     'navigateTo',
     'abortNavigation',
@@ -110,11 +112,9 @@ export const vuePreset = defineUnimportPreset({
 const vueRouterPreset = defineUnimportPreset({
   from: 'vue-router/composables',
   imports: [
-    'useRoute',
     'onBeforeRouteLeave',
     'onBeforeRouteUpdate',
-    'useLink',
-    'useRouter'
+    'useLink'
   ]
 })
 

--- a/src/runtime/capi.legacy.ts
+++ b/src/runtime/capi.legacy.ts
@@ -1,8 +1,7 @@
 import { defu } from 'defu'
 import { computed, getCurrentInstance as getVM, isReactive, isRef, onBeforeMount, onServerPrefetch, reactive, ref, set, shallowRef, toRaw, toRefs, watch } from 'vue'
-import { useRouter as _useRouter, useRoute as _useRoute } from 'vue-router/composables'
 import { useNuxtApp } from './app'
-import { useState } from './composables'
+import { useRouter as _useRouter, useRoute as _useRoute, useState } from './composables'
 
 // Vue composition API export
 export {

--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -1,11 +1,12 @@
 import { getCurrentInstance, onBeforeUnmount, isRef, watch, reactive, toRef, isReactive, Ref, set } from 'vue'
 import type { CombinedVueInstance } from 'vue/types/vue'
 import type { MetaInfo } from 'vue-meta'
+import type VueRouter from 'vue-router'
 import type { Location, RawLocation, Route } from 'vue-router'
 import type { RuntimeConfig } from '@nuxt/schema'
 import { sendRedirect } from 'h3'
 import { defu } from 'defu'
-import { useRouter } from 'vue-router/composables'
+import { useRouter as useVueRouter, useRoute as useVueRoute } from 'vue-router/composables'
 import { joinURL } from 'ufo'
 import { useNuxtApp } from './app'
 
@@ -31,6 +32,36 @@ export const useRuntimeConfig = () => {
 
   nuxtApp._config = reactive(nuxtApp.$config)
   return nuxtApp._config as RuntimeConfig
+}
+
+// Auto-import equivalents for `vue-router`
+export const useRouter = () => {
+  if (getCurrentInstance()) {
+    return useVueRouter()
+  }
+
+  // @ts-expect-error nuxt2Context is not typed fully
+  return useNuxtApp()?.nuxt2Context.app.router as VueRouter
+}
+
+// This provides an equivalent interface to `vue-router` (unlike legacy implementation)
+export const useRoute = () => {
+  if (getCurrentInstance()) {
+    return useVueRoute()
+  }
+
+  const nuxtApp = useNuxtApp()
+
+  if (!nuxtApp._route) {
+    Object.defineProperty(nuxtApp, '__route', {
+      get: () => nuxtApp.nuxt2Context.app.context.route
+    })
+    nuxtApp._route = reactive(nuxtApp.__route)
+    const router = useRouter()
+    router.afterEach(route => Object.assign(nuxtApp._route, route))
+  }
+
+  return nuxtApp._route as Route
 }
 
 // payload.state is used for vuex by nuxt 2


### PR DESCRIPTION
This reverts commit 5e5fa505163c78f4ffb7ab053a7996977c43caf9.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/bridge/issues/554, https://github.com/nuxt-modules/color-mode/issues/169

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When we switched to using native vue-router composables in https://github.com/nuxt/bridge/pull/533, we lost support for using `useRoute` and `useRouter` in Nuxt plugins, middleware, etc. (ie. anywhere outside of a component). This PR reverts that change in that if called outside a composable it will revert to previous behaviour. However, within a component, we still use the native `vue-router` composable.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

