### PR TITLE
fix: regression in entrypoint with CDN URL

### DIFF
--- a/src/vite/manifest.ts
+++ b/src/vite/manifest.ts
@@ -94,11 +94,11 @@ export async function generateBuildManifest (ctx: ViteBuildContext) {
     polyfill,
     'var appConfig = window && window.__NUXT__ && window.__NUXT__.config.app || {}',
     'var publicBase = appConfig.cdnURL || appConfig.baseURL || "/"',
-    'function joinURL (a, b) { return a[a.length -1] !== "/" ? a + "/" + b : a + b }',
+    'function joinURL (a, b) { return a.replace(/\\/+$/, "") + "/" + b.replace(/^\\/+/, "") }',
     'globalThis.__publicAssetsURL = function(id) { return joinURL(publicBase, id || "") }',
     'globalThis.__buildAssetsURL = function(id) { return joinURL(publicBase, joinURL(appConfig.buildAssetsDir, id || "")) }',
     `var imports = ${JSON.stringify([...clientImports])};`,
-    'imports.reduce(function(p, id){return p.then(function(){return System.import(__buildAssetsURL(id).slice(1))})}, Promise.resolve())'
+    'imports.reduce(function(p, id){return p.then(function(){return System.import(__buildAssetsURL(id))})}, Promise.resolve())'
   ].join('\n')
   const clientEntryName = 'entry-legacy.' + hash(clientEntryCode) + '.js'
 


### PR DESCRIPTION
### 🔗 Linked issue

#580

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes entrypoint-legacy not loading any further modules when the production build is started with `NUXT_APP_CDN_URL=https://cdn.url` due to `.slice(1)` mangling the URLs to `ttps://cdn.ur/_nuxt/module.js` (note the missing `h`).

Resolves #580.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

