### PR TITLE
fix: correct `redirectLocation` path resolution

### DIFF
--- a/packages/bridge/src/runtime/composables.ts
+++ b/packages/bridge/src/runtime/composables.ts
@@ -213,7 +213,7 @@ export const navigateTo = (to: RawLocation | undefined | null, options?: Navigat
   if (process.server) {
     const nuxtApp = useNuxtApp()
     if (nuxtApp.ssrContext && nuxtApp.ssrContext.event) {
-      const redirectLocation = isExternal ? toPath : joinURL(useRuntimeConfig().app.baseURL, router.resolve(to).fullPath || '/')
+      const redirectLocation = isExternal ? toPath : joinURL(useRuntimeConfig().app.baseURL, router.resolve(to).resolved.fullPath || '/')
       return nuxtApp.callHook('app:redirected').then(() => sendRedirect(nuxtApp.ssrContext!.event, redirectLocation, options?.redirectCode || 302))
     }
   }

--- a/playground/pages/navigate-to.vue
+++ b/playground/pages/navigate-to.vue
@@ -3,5 +3,5 @@
 </template>
 
 <script setup>
-navigateTo('/', { replace: true, redirectCode: 301 })
+navigateTo('/navigation-target', { replace: true, redirectCode: 301 })
 </script>

--- a/playground/pages/navigation-target.vue
+++ b/playground/pages/navigation-target.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Navigated successfully</div>
+</template>

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -23,7 +23,7 @@ describe('pages', () => {
 describe('navigate', () => {
   it('should redirect to index with navigateTo', async () => {
     const { headers } = await fetch('/navigate-to/', { redirect: 'manual' })
-    expect(headers.get('location')).toEqual('/')
+    expect(headers.get('location')).toEqual('/navigation-target')
     await expectNoClientErrors('/navigate-to/')
   })
   it('should redirect to index with navigateTo and 301 code', async () => {
@@ -184,7 +184,7 @@ describe('dynamic paths', () => {
     await startServer()
     const { headers } = await fetch('/foo/navigate-to/', { redirect: 'manual' })
 
-    expect(headers.get('location')).toEqual('/foo/')
+    expect(headers.get('location')).toEqual('/foo/navigation-target')
   })
 
   it('should allow setting CDN URL', async () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves https://github.com/nuxt/bridge/issues/681

Quite funny moment: tests was working, because they tested redirect to `/` location, which was the fallback. I've updated the tests to check non-fallback page. I guess we need more to cover.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.

