### PR TITLE
feat: backport `pages` config option from v3

### DIFF
--- a/packages/bridge-schema/src/config/adhoc.ts
+++ b/packages/bridge-schema/src/config/adhoc.ts
@@ -1,0 +1,11 @@
+import { defineUntypedSchema } from 'untyped'
+
+export default defineUntypedSchema({
+  /**
+   * Whether to use the vue-router integration in Nuxt 3/Nuxt 2 bridge. If you do not provide a value it will be
+   * enabled if you have a `pages/` directory in your source folder.
+   *
+   * @type {boolean}
+   */
+  pages: undefined
+})

--- a/packages/bridge-schema/src/config/index.ts
+++ b/packages/bridge-schema/src/config/index.ts
@@ -1,4 +1,4 @@
-
+import adhoc from './adhoc'
 import app from './app'
 import build from './build'
 import cli from './cli'
@@ -28,6 +28,7 @@ Schema differences from Nuxt2:
 */
 
 export default {
+  ...adhoc,
   ...app,
   ...build,
   ...cli,

--- a/packages/bridge/module.cjs
+++ b/packages/bridge/module.cjs
@@ -26,6 +26,13 @@ module.exports.defineNuxtConfig = (config = {}) => {
     // Ensure other modules register their hooks before
     config.buildModules.push('@nuxt/bridge')
   }
+
+  // Turn on vue-router if pages is enabled. Backport of nuxt 3 behavior
+  if (config.pages && typeof config.build?.createRoutes !== 'function') {
+    config.build = config.build || {}
+    config.build.createRoutes = () => []
+  }
+
   config.buildModules.unshift(async function () {
     const nuxt = this.nuxt
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

This PR resolves proposal from https://github.com/nuxt/bridge/issues/687

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
This PR backports `pages` option from Nuxt and removes the need to keep `pages` folder with `.gitkeep` inside.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

