### PR TITLE
chore: update to recommend 2.16.0 rather than edge channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ Learn more about in our documentation on [how to contribute to Nuxt](https://nux
 
 ### Upgrade to the latest Nuxt 2
 
-Make sure your dev server (`nuxt dev`) isn't running, remove any package lock files (`package-lock.json` and `yarn.lock`), and install the latest `nuxt-edge`:
+Make sure your dev server (`nuxt dev`) isn't running, remove any package lock files (`package-lock.json` and `yarn.lock`), and install the latest `nuxt` version:
 
 ```diff [package.json]
 - "nuxt": "^2.15.0"
-+ "nuxt-edge": "latest"
++ "nuxt": "^2.16.0"
 ```
 
 Then, reinstall your dependencies:

--- a/playground/package.json
+++ b/playground/package.json
@@ -11,6 +11,6 @@
   "devDependencies": {
     "@nuxt/bridge": "latest",
     "@vueuse/head": "^0.9.8",
-    "nuxt-edge": "latest"
+    "nuxt": "^2.16.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,11 +196,11 @@ importers:
     specifiers:
       '@nuxt/bridge': workspace:*
       '@vueuse/head': ^0.9.8
-      nuxt-edge: latest
+      nuxt: ^2.16.0
     devDependencies:
       '@nuxt/bridge': link:../packages/bridge
       '@vueuse/head': 0.9.8
-      nuxt-edge: 2.16.0-27923058.4ecdc72
+      nuxt: 2.16.0
 
 packages:
 
@@ -2216,30 +2216,6 @@ packages:
       rimraf: 3.0.2
     dev: true
 
-  /@nuxt/babel-preset-app-edge/2.16.0-27923058.4ecdc72:
-    resolution: {integrity: sha512-b8zFsONFV5Sk1JvdPX76xIMfz2lDl0SqEOuTe/7StFJ6JoeoJ+q+aTCR+9AF98j5ZWnuTMUX6/CVtzF7qi9Pjg==}
-    dependencies:
-      '@babel/compat-data': 7.20.14
-      '@babel/core': 7.20.12
-      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-proposal-decorators': 7.20.13_@babel+core@7.20.12
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-proposal-optional-chaining': 7.20.7_@babel+core@7.20.12
-      '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-runtime': 7.19.6_@babel+core@7.20.12
-      '@babel/preset-env': 7.20.2_@babel+core@7.20.12
-      '@babel/runtime': 7.20.13
-      '@vue/babel-preset-jsx': 1.4.0_@babel+core@7.20.12
-      core-js: 3.26.1
-      core-js-compat: 3.27.2
-      regenerator-runtime: 0.13.11
-    transitivePeerDependencies:
-      - supports-color
-      - vue
-    dev: true
-
   /@nuxt/babel-preset-app/2.15.8_vue@2.7.14:
     resolution: {integrity: sha512-z23bY5P7dLTmIbk0ZZ95mcEXIEER/mQCOqEp2vxnzG2nurks+vq6tNcUAXqME1Wl6aXWTXlqky5plBe7RQHzhQ==}
     dependencies:
@@ -2264,86 +2240,28 @@ packages:
       - vue
     dev: true
 
-  /@nuxt/builder-edge/2.16.0-27923058.4ecdc72:
-    resolution: {integrity: sha512-UOSdYmRHxACvegMP8NhAmUwHbmkg6VqdZm1OP0TjJnEXCnKhp0gBklgWDNMxHdchL0GDvfboIBao45FhWhhhZg==}
+  /@nuxt/babel-preset-app/2.16.0:
+    resolution: {integrity: sha512-8oIfb19Q6dvnSoQbmFXlz0eVnKjWq3ei/AKHXUHQ9ss7q2ZJPc8PxLHFyHo07Q1kaaitRYu+/l+jw2DGXLs9qg==}
     dependencies:
-      '@nuxt/devalue': 2.0.0
-      '@nuxt/utils-edge': 2.16.0-27923058.4ecdc72
-      '@nuxt/vue-app-edge': 2.16.0-27923058.4ecdc72
-      '@nuxt/webpack-edge': 2.16.0-27923058.4ecdc72
-      chalk: 4.1.2
-      chokidar: 3.5.3
-      consola: 2.15.3
-      fs-extra: 10.1.0
-      glob: 8.1.0
-      hash-sum: 2.0.0
-      ignore: 5.2.4
-      lodash: 4.17.21
-      pify: 5.0.0
-      serialize-javascript: 6.0.1
-      upath: 2.0.1
+      '@babel/compat-data': 7.20.14
+      '@babel/core': 7.20.12
+      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.20.12
+      '@babel/plugin-proposal-decorators': 7.20.13_@babel+core@7.20.12
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.20.12
+      '@babel/plugin-proposal-optional-chaining': 7.20.7_@babel+core@7.20.12
+      '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.20.12
+      '@babel/plugin-transform-runtime': 7.19.6_@babel+core@7.20.12
+      '@babel/preset-env': 7.20.2_@babel+core@7.20.12
+      '@babel/runtime': 7.20.13
+      '@vue/babel-preset-jsx': 1.4.0_@babel+core@7.20.12
+      core-js: 3.26.1
+      core-js-compat: 3.27.2
+      regenerator-runtime: 0.13.11
     transitivePeerDependencies:
-      - '@vue/compiler-sfc'
-      - arc-templates
-      - atpl
-      - babel-core
-      - bluebird
-      - bracket-template
-      - bufferutil
-      - coffee-script
-      - dot
-      - dust
-      - dustjs-helpers
-      - dustjs-linkedin
-      - eco
-      - ect
-      - ejs
-      - haml-coffee
-      - hamlet
-      - hamljs
-      - handlebars
-      - hogan.js
-      - htmling
-      - jade
-      - jazz
-      - jqtpl
-      - just
-      - liquid-node
-      - liquor
-      - marko
-      - mote
-      - mustache
-      - nunjucks
-      - plates
-      - pug
-      - qejs
-      - ractive
-      - razor-tmpl
-      - react
-      - react-dom
-      - slm
-      - squirrelly
       - supports-color
-      - swig
-      - swig-templates
-      - teacup
-      - templayed
-      - then-jade
-      - then-pug
-      - tinyliquid
-      - toffee
-      - twig
-      - twing
-      - typescript
-      - underscore
-      - utf-8-validate
-      - vash
-      - velocityjs
       - vue
-      - walrus
-      - webpack-cli
-      - webpack-command
-      - whiskers
     dev: true
 
   /@nuxt/builder/2.15.8_vue@2.7.14:
@@ -2429,37 +2347,86 @@ packages:
       - whiskers
     dev: true
 
-  /@nuxt/cli-edge/2.16.0-27923058.4ecdc72:
-    resolution: {integrity: sha512-B+IXbwfEKPgCHmgprnGyTSqvCNK2NAF7dRXWtnmEGKgs+NRbX//31PFSz4DaY0deJh2tr5OpdmBOXT/mAOsNmg==}
-    hasBin: true
+  /@nuxt/builder/2.16.0:
+    resolution: {integrity: sha512-BkmCvRtSJJeoZGOsjiE03fUtjjfoMy0au8Gco3bcwKu/s2lzkWlT2mcWV4s37eVTSQUMRRyT3huTHEmcNhw3Hw==}
     dependencies:
-      '@nuxt/config-edge': 2.16.0-27923058.4ecdc72
-      '@nuxt/utils-edge': 2.16.0-27923058.4ecdc72
-      boxen: 5.1.2
+      '@nuxt/devalue': 2.0.0
+      '@nuxt/utils': 2.16.0
+      '@nuxt/vue-app': 2.16.0
+      '@nuxt/webpack': 2.16.0
       chalk: 4.1.2
-      compression: 1.7.4
-      connect: 3.7.0
+      chokidar: 3.5.3
       consola: 2.15.3
-      crc: 4.3.2
-      defu: 6.1.2
-      destr: 1.2.2
-      execa: 5.1.1
-      exit: 0.1.2
       fs-extra: 10.1.0
-      globby: 11.1.0
-      hable: 3.0.0
+      glob: 8.1.0
+      hash-sum: 2.0.0
+      ignore: 5.2.4
       lodash: 4.17.21
-      minimist: 1.2.7
-      opener: 1.5.2
-      pretty-bytes: 5.6.0
-      semver: 7.3.8
-      serve-static: 1.15.0
-      std-env: 3.3.2
+      pify: 5.0.0
+      serialize-javascript: 6.0.1
       upath: 2.0.1
-      wrap-ansi: 7.0.0
     transitivePeerDependencies:
-      - buffer
+      - '@vue/compiler-sfc'
+      - arc-templates
+      - atpl
+      - babel-core
+      - bluebird
+      - bracket-template
+      - bufferutil
+      - coffee-script
+      - dot
+      - dust
+      - dustjs-helpers
+      - dustjs-linkedin
+      - eco
+      - ect
+      - ejs
+      - haml-coffee
+      - hamlet
+      - hamljs
+      - handlebars
+      - hogan.js
+      - htmling
+      - jade
+      - jazz
+      - jqtpl
+      - just
+      - liquid-node
+      - liquor
+      - marko
+      - mote
+      - mustache
+      - nunjucks
+      - plates
+      - pug
+      - qejs
+      - ractive
+      - razor-tmpl
+      - react
+      - react-dom
+      - slm
+      - squirrelly
       - supports-color
+      - swig
+      - swig-templates
+      - teacup
+      - templayed
+      - then-jade
+      - then-pug
+      - tinyliquid
+      - toffee
+      - twig
+      - twing
+      - typescript
+      - underscore
+      - utf-8-validate
+      - vash
+      - velocityjs
+      - vue
+      - walrus
+      - webpack-cli
+      - webpack-command
+      - whiskers
     dev: true
 
   /@nuxt/cli/2.15.8:
@@ -2494,6 +2461,39 @@ packages:
       - supports-color
     dev: true
 
+  /@nuxt/cli/2.16.0:
+    resolution: {integrity: sha512-7iL5u4EfpDo5DQy5RwZwohYuH3ucTDCSm5uu3FXsBZharYe+zcQeyqmILbbiVGLXhml5MDV3qCVocbFZeGXRJw==}
+    hasBin: true
+    dependencies:
+      '@nuxt/config': 2.16.0
+      '@nuxt/utils': 2.16.0
+      boxen: 5.1.2
+      chalk: 4.1.2
+      compression: 1.7.4
+      connect: 3.7.0
+      consola: 2.15.3
+      crc: 4.3.2
+      defu: 6.1.2
+      destr: 1.2.2
+      execa: 5.1.1
+      exit: 0.1.2
+      fs-extra: 10.1.0
+      globby: 11.1.0
+      hable: 3.0.0
+      lodash: 4.17.21
+      minimist: 1.2.7
+      opener: 1.5.2
+      pretty-bytes: 5.6.0
+      semver: 7.3.8
+      serve-static: 1.15.0
+      std-env: 3.3.2
+      upath: 2.0.1
+      wrap-ansi: 7.0.0
+    transitivePeerDependencies:
+      - buffer
+      - supports-color
+    dev: true
+
   /@nuxt/components/2.2.1:
     resolution: {integrity: sha512-r1LHUzifvheTnJtYrMuA+apgsrEJbxcgFKIimeXKb+jl8TnPWdV3egmrxBCaDJchrtY/wmHyP47tunsft7AWwg==}
     peerDependencies:
@@ -2507,20 +2507,6 @@ packages:
       semver: 7.3.8
       upath: 2.0.1
       vue-template-compiler: 2.7.14
-    dev: true
-
-  /@nuxt/config-edge/2.16.0-27923058.4ecdc72:
-    resolution: {integrity: sha512-wbuJy2O8lprxxxuplmKPxdJgEcnPl8iXvxnvjKBvTO/gEUoVZM0lXK1AKbwPgfg0uv9+GEw0B+W/zxUHFy7TYg==}
-    dependencies:
-      '@nuxt/utils-edge': 2.16.0-27923058.4ecdc72
-      consola: 2.15.3
-      defu: 6.1.2
-      destr: 1.2.2
-      dotenv: 16.0.3
-      lodash: 4.17.21
-      rc9: 2.0.1
-      std-env: 3.3.2
-      ufo: 1.0.1
     dev: true
 
   /@nuxt/config/2.15.8:
@@ -2537,19 +2523,18 @@ packages:
       ufo: 0.7.11
     dev: true
 
-  /@nuxt/core-edge/2.16.0-27923058.4ecdc72:
-    resolution: {integrity: sha512-a8k0bzrrsp543TwNmwwL5ARQRjSJBF7Tio/jMFRUXa5U0ijNN0/twULn9F6B+Mwtjpb28g7NKw5zz9aVmdN8ug==}
+  /@nuxt/config/2.16.0:
+    resolution: {integrity: sha512-ysi9G4C0tW0dFyvDyejO3/ldvBQi0CzksaUtXhYatbQxcd/FqoXVf/yQplFKat1T2gnmYj/qFZRu2WhlD21OmA==}
     dependencies:
-      '@nuxt/config-edge': 2.16.0-27923058.4ecdc72
-      '@nuxt/server-edge': 2.16.0-27923058.4ecdc72
-      '@nuxt/utils-edge': 2.16.0-27923058.4ecdc72
+      '@nuxt/utils': 2.16.0
       consola: 2.15.3
-      fs-extra: 10.1.0
-      hable: 3.0.0
-      hash-sum: 2.0.0
+      defu: 6.1.2
+      destr: 1.2.2
+      dotenv: 16.0.3
       lodash: 4.17.21
-    transitivePeerDependencies:
-      - supports-color
+      rc9: 2.0.1
+      std-env: 3.3.2
+      ufo: 1.0.1
     dev: true
 
   /@nuxt/core/2.15.8:
@@ -2560,6 +2545,21 @@ packages:
       '@nuxt/utils': 2.15.8
       consola: 2.15.3
       fs-extra: 9.1.0
+      hable: 3.0.0
+      hash-sum: 2.0.0
+      lodash: 4.17.21
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@nuxt/core/2.16.0:
+    resolution: {integrity: sha512-zhJ9YzKIucqQa+FWUlhCdHpn5k4uL1+FW5MiAELWutNsr8RyX2ZJQxENKMp5eZIYs/vMcJ0a6pS8AoLnkjOuHg==}
+    dependencies:
+      '@nuxt/config': 2.16.0
+      '@nuxt/server': 2.16.0
+      '@nuxt/utils': 2.16.0
+      consola: 2.15.3
+      fs-extra: 10.1.0
       hable: 3.0.0
       hash-sum: 2.0.0
       lodash: 4.17.21
@@ -2589,20 +2589,6 @@ packages:
       webpack: 4.46.0
     dev: true
 
-  /@nuxt/generator-edge/2.16.0-27923058.4ecdc72:
-    resolution: {integrity: sha512-1aNAJtZc/MbnoLaz5tjrjmkoaQUBFs5Ur1YPw98jT87q1sND03FjIZ4KBfRQdfBVThylqov2DNi6ftsF2SZCcg==}
-    dependencies:
-      '@nuxt/utils-edge': 2.16.0-27923058.4ecdc72
-      chalk: 4.1.2
-      consola: 2.15.3
-      defu: 6.1.2
-      devalue: 2.0.1
-      fs-extra: 10.1.0
-      html-minifier: 4.0.0
-      node-html-parser: 6.1.4
-      ufo: 1.0.1
-    dev: true
-
   /@nuxt/generator/2.15.8:
     resolution: {integrity: sha512-hreLdYbBIe3SWcP8LsMG7OlDTx2ZVucX8+f8Vrjft3Q4r8iCwLMYC1s1N5etxeHAZfS2kZiLmF92iscOdfbgMQ==}
     dependencies:
@@ -2615,6 +2601,20 @@ packages:
       html-minifier: 4.0.0
       node-html-parser: 3.3.6
       ufo: 0.7.11
+    dev: true
+
+  /@nuxt/generator/2.16.0:
+    resolution: {integrity: sha512-eHPPqoxhQkgjx+eSiJe1aNp8KNmnMckqFK7YJyetCz+nsgbgrS7HzLjvMMUQl7LqiUWPMpleCboYQBeO7TqW6A==}
+    dependencies:
+      '@nuxt/utils': 2.16.0
+      chalk: 4.1.2
+      consola: 2.15.3
+      defu: 6.1.2
+      devalue: 2.0.1
+      fs-extra: 10.1.0
+      html-minifier: 4.0.0
+      node-html-parser: 6.1.4
+      ufo: 1.0.1
     dev: true
 
   /@nuxt/kit/3.1.2:
@@ -2703,30 +2703,6 @@ packages:
       - rollup
       - supports-color
 
-  /@nuxt/server-edge/2.16.0-27923058.4ecdc72:
-    resolution: {integrity: sha512-335RTQunagVlKpBLMjZkLUMjVHDDEmvP7+75WNBwxSiJRPX34vySUtW5jbYjbQZENZawqDaIAbn87zaLM5pilw==}
-    dependencies:
-      '@nuxt/utils-edge': 2.16.0-27923058.4ecdc72
-      '@nuxt/vue-renderer-edge': 2.16.0-27923058.4ecdc72
-      '@nuxtjs/youch': 4.2.3
-      compression: 1.7.4
-      connect: 3.7.0
-      consola: 2.15.3
-      etag: 1.8.1
-      fresh: 0.5.2
-      fs-extra: 10.1.0
-      ip: 1.1.8
-      launch-editor-middleware: 2.6.0
-      on-headers: 1.0.2
-      pify: 5.0.0
-      serve-placeholder: 2.0.1
-      serve-static: 1.15.0
-      server-destroy: 1.0.1
-      ufo: 1.0.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@nuxt/server/2.15.8:
     resolution: {integrity: sha512-E4EtXudxtWQBUHMHOxFwm5DlPOkJbW+iF1+zc0dGmXLscep1KWPrlP+4nrpZj8/UKzpupamE8ZTS9I4IbnExVA==}
     dependencies:
@@ -2747,6 +2723,30 @@ packages:
       serve-static: 1.15.0
       server-destroy: 1.0.1
       ufo: 0.7.11
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@nuxt/server/2.16.0:
+    resolution: {integrity: sha512-hxb89ywMp/QjChDjAvmcxN8lRSg4uV4/0Job0fpvCSvYznQPXvIV2Hss0MilfEpg9DKuTb2fR9Y96904T1ZCcw==}
+    dependencies:
+      '@nuxt/utils': 2.16.0
+      '@nuxt/vue-renderer': 2.16.0
+      '@nuxtjs/youch': 4.2.3
+      compression: 1.7.4
+      connect: 3.7.0
+      consola: 2.15.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      fs-extra: 10.1.0
+      ip: 1.1.8
+      launch-editor-middleware: 2.6.0
+      on-headers: 1.0.2
+      pify: 5.0.0
+      serve-placeholder: 2.0.1
+      serve-static: 1.15.0
+      server-destroy: 1.0.1
+      ufo: 1.0.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2854,23 +2854,6 @@ packages:
     resolution: {integrity: sha512-PjVETP7+iZXAs5Q8O4ivl4t6qjWZMZqwiTVogUXHoHGZZcw7GZW3u3tzfYfE1HbzyYJfr236IXqQ02MeR8Fz2w==}
     dev: false
 
-  /@nuxt/utils-edge/2.16.0-27923058.4ecdc72:
-    resolution: {integrity: sha512-/ATGtzQedtt9L2EjSfPRZVLUK3EwQTeZovgskgo08AmyAJto2qEMc2WTDMFcminiudxj17QdXOGrVpO/1Jp0kQ==}
-    dependencies:
-      consola: 2.15.3
-      create-require: 1.1.1
-      fs-extra: 10.1.0
-      hash-sum: 2.0.0
-      jiti: 1.16.2
-      lodash: 4.17.21
-      proper-lockfile: 4.1.2
-      semver: 7.3.8
-      serialize-javascript: 6.0.1
-      signal-exit: 3.0.7
-      ua-parser-js: 1.0.33
-      ufo: 1.0.1
-    dev: true
-
   /@nuxt/utils/2.15.8:
     resolution: {integrity: sha512-e0VBarUbPiQ4ZO1T58puoFIuXme7L5gk1QfwyxOONlp2ryE7aRyZ8X/mryuOiIeyP64c4nwSUtN7q9EUWRb7Lg==}
     dependencies:
@@ -2888,19 +2871,21 @@ packages:
       ufo: 0.7.11
     dev: true
 
-  /@nuxt/vue-app-edge/2.16.0-27923058.4ecdc72:
-    resolution: {integrity: sha512-n5MVs19sDJXF11s3h7fZN0WHCKWKUFUKCxUYT7sazx0EzMtEqMnyTqfZaKnoRaD/HX6Eh2eKRao5lDzk4XwtZw==}
+  /@nuxt/utils/2.16.0:
+    resolution: {integrity: sha512-/6eLMKYn/hFr17HNtcgIHaO1rKqrSfGxABPQCikLIpq/hRcXz0tCQHgwLfG9nEzFyY7fzulPIICjRB9EEEe3tA==}
     dependencies:
-      node-fetch-native: 1.0.1
+      consola: 2.15.3
+      create-require: 1.1.1
+      fs-extra: 10.1.0
+      hash-sum: 2.0.0
+      jiti: 1.16.2
+      lodash: 4.17.21
+      proper-lockfile: 4.1.2
+      semver: 7.3.8
+      serialize-javascript: 6.0.1
+      signal-exit: 3.0.7
+      ua-parser-js: 1.0.33
       ufo: 1.0.1
-      unfetch: 5.0.0
-      vue: 2.7.14
-      vue-client-only: 2.1.0
-      vue-meta: 2.4.0
-      vue-no-ssr: 1.1.1
-      vue-router: 3.6.5_vue@2.7.14
-      vue-template-compiler: 2.7.14
-      vuex: 3.6.2_vue@2.7.14
     dev: true
 
   /@nuxt/vue-app/2.15.8:
@@ -2920,20 +2905,19 @@ packages:
       - encoding
     dev: true
 
-  /@nuxt/vue-renderer-edge/2.16.0-27923058.4ecdc72:
-    resolution: {integrity: sha512-RMsy7tHUEDWrlbeDhejfHGNW1S3Sbvnj6uADfFCX9KmelRKFbBiUhWjFxcxdBWwMc7O8eoUGhkFeen4uTTa5VA==}
+  /@nuxt/vue-app/2.16.0:
+    resolution: {integrity: sha512-WVvwq5+KcRTM9umplGi0LZrl37OuwwNH5vKBxwY1sW8ApTiCbK1He+I55hmheEDUhumCEcj4AuEtypnX6LTj9w==}
     dependencies:
-      '@nuxt/devalue': 2.0.0
-      '@nuxt/utils-edge': 2.16.0-27923058.4ecdc72
-      consola: 2.15.3
-      defu: 6.1.2
-      fs-extra: 10.1.0
-      lodash: 4.17.21
-      lru-cache: 5.1.1
+      node-fetch-native: 1.0.1
       ufo: 1.0.1
+      unfetch: 5.0.0
       vue: 2.7.14
+      vue-client-only: 2.1.0
       vue-meta: 2.4.0
-      vue-server-renderer: 2.7.14
+      vue-no-ssr: 1.1.1
+      vue-router: 3.6.5_vue@2.7.14
+      vue-template-compiler: 2.7.14
+      vuex: 3.6.2_vue@2.7.14
     dev: true
 
   /@nuxt/vue-renderer/2.15.8:
@@ -2952,56 +2936,70 @@ packages:
       vue-server-renderer: 2.7.14
     dev: true
 
-  /@nuxt/webpack-edge/2.16.0-27923058.4ecdc72:
-    resolution: {integrity: sha512-hHP4339Y0AU37BcQiO/oFj12RQhGC7m8tKtr/gHiUHVwdZf6xqzwODQJt/vCyWQaY574JIZ/1TbUOtAUY9mBlg==}
+  /@nuxt/vue-renderer/2.16.0:
+    resolution: {integrity: sha512-7bo3ixPR8mCwl3V2fp8COcjOzpsILiYPmMfGBZxWOVDL3/ktOwh8Id4p2uUeN+HKybxjRQKPUL/OKeSOUw14xA==}
+    dependencies:
+      '@nuxt/devalue': 2.0.0
+      '@nuxt/utils': 2.16.0
+      consola: 2.15.3
+      defu: 6.1.2
+      fs-extra: 10.1.0
+      lodash: 4.17.21
+      lru-cache: 5.1.1
+      ufo: 1.0.1
+      vue: 2.7.14
+      vue-meta: 2.4.0
+      vue-server-renderer: 2.7.14
+    dev: true
+
+  /@nuxt/webpack/2.15.8_vue@2.7.14:
+    resolution: {integrity: sha512-CzJYFed23Ow/UK0+cI1FVthDre1p2qc8Q97oizG39d3/SIh3aUHjgj8c60wcR+RSxVO0FzZMXkmq02NmA7vWJg==}
     dependencies:
       '@babel/core': 7.20.12
-      '@nuxt/babel-preset-app-edge': 2.16.0-27923058.4ecdc72
+      '@nuxt/babel-preset-app': 2.15.8_vue@2.7.14
       '@nuxt/friendly-errors-webpack-plugin': 2.5.2_webpack@4.46.0
-      '@nuxt/utils-edge': 2.16.0-27923058.4ecdc72
+      '@nuxt/utils': 2.15.8
       babel-loader: 8.3.0_nwtvwtk5tmh22l2urnqucz7kqu
       cache-loader: 4.1.0_webpack@4.46.0
       caniuse-lite: 1.0.30001450
       consola: 2.15.3
-      css-loader: 5.2.7_webpack@4.46.0
-      cssnano: 5.1.14_postcss@8.4.21
+      css-loader: 4.3.0_webpack@4.46.0
+      cssnano: 4.1.11
       eventsource-polyfill: 0.9.6
       extract-css-chunks-webpack-plugin: 4.9.0_webpack@4.46.0
       file-loader: 6.2.0_webpack@4.46.0
-      glob: 8.1.0
+      glob: 7.2.3
       hard-source-webpack-plugin: 0.13.1_webpack@4.46.0
       hash-sum: 2.0.0
       html-webpack-plugin: 4.5.2_webpack@4.46.0
       lodash: 4.17.21
       memory-fs: 0.5.0
-      optimize-css-assets-webpack-plugin: 6.0.1_webpack@4.46.0
+      optimize-css-assets-webpack-plugin: 5.0.8_webpack@4.46.0
       pify: 5.0.0
       pnp-webpack-plugin: 1.7.0
-      postcss: 8.4.21
-      postcss-import: 15.1.0_postcss@8.4.21
+      postcss: 7.0.39
+      postcss-import: 12.0.1
       postcss-import-resolver: 2.0.0
-      postcss-loader: 4.3.0_4dftvqknpgmotzmzzqmnfvmmye
-      postcss-preset-env: 8.0.1_postcss@8.4.21
-      postcss-url: 10.1.3_postcss@8.4.21
+      postcss-loader: 3.0.0
+      postcss-preset-env: 6.7.1
+      postcss-url: 8.0.0
       semver: 7.3.8
-      std-env: 3.3.2
+      std-env: 2.3.1
       style-resources-loader: 1.5.0_webpack@4.46.0
       terser-webpack-plugin: 4.2.3_webpack@4.46.0
       thread-loader: 3.0.4_webpack@4.46.0
       time-fix-plugin: 2.0.7_webpack@4.46.0
-      ufo: 1.0.1
-      upath: 2.0.1
+      ufo: 0.7.11
       url-loader: 4.1.1_lit45vopotvaqup7lrvlnvtxwy
-      vue-loader: 15.10.1_advha552eakciyizojust5gnre
+      vue-loader: 15.10.1_mi7kfaeh4nmupiqclubmvzt3ru
       vue-style-loader: 4.1.3
       vue-template-compiler: 2.7.14
-      watchpack: 2.4.0
       webpack: 4.46.0
       webpack-bundle-analyzer: 4.7.0
-      webpack-dev-middleware: 5.3.3_webpack@4.46.0
+      webpack-dev-middleware: 4.3.0_webpack@4.46.0
       webpack-hot-middleware: 2.25.3
       webpack-node-externals: 3.0.0
-      webpackbar: 5.0.2_webpack@4.46.0
+      webpackbar: 4.0.0_webpack@4.46.0
     transitivePeerDependencies:
       - '@vue/compiler-sfc'
       - arc-templates
@@ -3066,54 +3064,56 @@ packages:
       - whiskers
     dev: true
 
-  /@nuxt/webpack/2.15.8_vue@2.7.14:
-    resolution: {integrity: sha512-CzJYFed23Ow/UK0+cI1FVthDre1p2qc8Q97oizG39d3/SIh3aUHjgj8c60wcR+RSxVO0FzZMXkmq02NmA7vWJg==}
+  /@nuxt/webpack/2.16.0:
+    resolution: {integrity: sha512-AWhVGm/dNnp2lWLVy2bI+Tvug6PUrp69CDDTXtpxheGWorJY/ldi+/Forrn9bqo01zv6TI1EgBUTmQSRl0kpdQ==}
     dependencies:
       '@babel/core': 7.20.12
-      '@nuxt/babel-preset-app': 2.15.8_vue@2.7.14
+      '@nuxt/babel-preset-app': 2.16.0
       '@nuxt/friendly-errors-webpack-plugin': 2.5.2_webpack@4.46.0
-      '@nuxt/utils': 2.15.8
+      '@nuxt/utils': 2.16.0
       babel-loader: 8.3.0_nwtvwtk5tmh22l2urnqucz7kqu
       cache-loader: 4.1.0_webpack@4.46.0
       caniuse-lite: 1.0.30001450
       consola: 2.15.3
-      css-loader: 4.3.0_webpack@4.46.0
-      cssnano: 4.1.11
+      css-loader: 5.2.7_webpack@4.46.0
+      cssnano: 5.1.14_postcss@8.4.21
       eventsource-polyfill: 0.9.6
       extract-css-chunks-webpack-plugin: 4.9.0_webpack@4.46.0
       file-loader: 6.2.0_webpack@4.46.0
-      glob: 7.2.3
+      glob: 8.1.0
       hard-source-webpack-plugin: 0.13.1_webpack@4.46.0
       hash-sum: 2.0.0
       html-webpack-plugin: 4.5.2_webpack@4.46.0
       lodash: 4.17.21
       memory-fs: 0.5.0
-      optimize-css-assets-webpack-plugin: 5.0.8_webpack@4.46.0
+      optimize-css-assets-webpack-plugin: 6.0.1_webpack@4.46.0
       pify: 5.0.0
       pnp-webpack-plugin: 1.7.0
-      postcss: 7.0.39
-      postcss-import: 12.0.1
+      postcss: 8.4.21
+      postcss-import: 15.1.0_postcss@8.4.21
       postcss-import-resolver: 2.0.0
-      postcss-loader: 3.0.0
-      postcss-preset-env: 6.7.1
-      postcss-url: 8.0.0
+      postcss-loader: 4.3.0_4dftvqknpgmotzmzzqmnfvmmye
+      postcss-preset-env: 8.0.1_postcss@8.4.21
+      postcss-url: 10.1.3_postcss@8.4.21
       semver: 7.3.8
-      std-env: 2.3.1
+      std-env: 3.3.2
       style-resources-loader: 1.5.0_webpack@4.46.0
       terser-webpack-plugin: 4.2.3_webpack@4.46.0
       thread-loader: 3.0.4_webpack@4.46.0
       time-fix-plugin: 2.0.7_webpack@4.46.0
-      ufo: 0.7.11
+      ufo: 1.0.1
+      upath: 2.0.1
       url-loader: 4.1.1_lit45vopotvaqup7lrvlnvtxwy
-      vue-loader: 15.10.1_mi7kfaeh4nmupiqclubmvzt3ru
+      vue-loader: 15.10.1_advha552eakciyizojust5gnre
       vue-style-loader: 4.1.3
       vue-template-compiler: 2.7.14
+      watchpack: 2.4.0
       webpack: 4.46.0
       webpack-bundle-analyzer: 4.7.0
-      webpack-dev-middleware: 4.3.0_webpack@4.46.0
+      webpack-dev-middleware: 5.3.3_webpack@4.46.0
       webpack-hot-middleware: 2.25.3
       webpack-node-externals: 3.0.0
-      webpackbar: 4.0.0_webpack@4.46.0
+      webpackbar: 5.0.2_webpack@4.46.0
     transitivePeerDependencies:
       - '@vue/compiler-sfc'
       - arc-templates
@@ -10338,26 +10338,26 @@ packages:
       fsevents: 2.3.2
     dev: false
 
-  /nuxt-edge/2.16.0-27923058.4ecdc72:
-    resolution: {integrity: sha512-a6tGBzC9PIAtQloOC/k6Z8NHXxqY10Uno+dYcUoiBTkq7OKDYisHB486O6nQ9OH0bnIe+VFpEJ9p2Flkq3DfdQ==}
+  /nuxt/2.15.8_vue@2.7.14:
+    resolution: {integrity: sha512-ceK3qLg/Baj7J8mK9bIxqw9AavrF+LXqwYEreBdY/a4Sj8YV4mIvhqea/6E7VTCNNGvKT2sJ/TTJjtfQ597lTA==}
     hasBin: true
     requiresBuild: true
     dependencies:
-      '@nuxt/babel-preset-app-edge': 2.16.0-27923058.4ecdc72
-      '@nuxt/builder-edge': 2.16.0-27923058.4ecdc72
-      '@nuxt/cli-edge': 2.16.0-27923058.4ecdc72
+      '@nuxt/babel-preset-app': 2.15.8_vue@2.7.14
+      '@nuxt/builder': 2.15.8_vue@2.7.14
+      '@nuxt/cli': 2.15.8
       '@nuxt/components': 2.2.1
-      '@nuxt/config-edge': 2.16.0-27923058.4ecdc72
-      '@nuxt/core-edge': 2.16.0-27923058.4ecdc72
-      '@nuxt/generator-edge': 2.16.0-27923058.4ecdc72
+      '@nuxt/config': 2.15.8
+      '@nuxt/core': 2.15.8
+      '@nuxt/generator': 2.15.8
       '@nuxt/loading-screen': 2.0.4
       '@nuxt/opencollective': 0.3.3
-      '@nuxt/server-edge': 2.16.0-27923058.4ecdc72
-      '@nuxt/telemetry': 1.4.1
-      '@nuxt/utils-edge': 2.16.0-27923058.4ecdc72
-      '@nuxt/vue-app-edge': 2.16.0-27923058.4ecdc72
-      '@nuxt/vue-renderer-edge': 2.16.0-27923058.4ecdc72
-      '@nuxt/webpack-edge': 2.16.0-27923058.4ecdc72
+      '@nuxt/server': 2.15.8
+      '@nuxt/telemetry': 1.3.7
+      '@nuxt/utils': 2.15.8
+      '@nuxt/vue-app': 2.15.8
+      '@nuxt/vue-renderer': 2.15.8
+      '@nuxt/webpack': 2.15.8_vue@2.7.14
     transitivePeerDependencies:
       - '@vue/compiler-sfc'
       - arc-templates
@@ -10365,7 +10365,6 @@ packages:
       - babel-core
       - bluebird
       - bracket-template
-      - buffer
       - bufferutil
       - coffee-script
       - consola
@@ -10425,26 +10424,26 @@ packages:
       - whiskers
     dev: true
 
-  /nuxt/2.15.8_vue@2.7.14:
-    resolution: {integrity: sha512-ceK3qLg/Baj7J8mK9bIxqw9AavrF+LXqwYEreBdY/a4Sj8YV4mIvhqea/6E7VTCNNGvKT2sJ/TTJjtfQ597lTA==}
+  /nuxt/2.16.0:
+    resolution: {integrity: sha512-3gcaQRDhz2kmouN29wavnfq3IE4PdT2O84LMT1Wa0SOb5vSasuljAiKunkXILS1HB3SOTyXc2JM9+zhG1awEZw==}
     hasBin: true
     requiresBuild: true
     dependencies:
-      '@nuxt/babel-preset-app': 2.15.8_vue@2.7.14
-      '@nuxt/builder': 2.15.8_vue@2.7.14
-      '@nuxt/cli': 2.15.8
+      '@nuxt/babel-preset-app': 2.16.0
+      '@nuxt/builder': 2.16.0
+      '@nuxt/cli': 2.16.0
       '@nuxt/components': 2.2.1
-      '@nuxt/config': 2.15.8
-      '@nuxt/core': 2.15.8
-      '@nuxt/generator': 2.15.8
+      '@nuxt/config': 2.16.0
+      '@nuxt/core': 2.16.0
+      '@nuxt/generator': 2.16.0
       '@nuxt/loading-screen': 2.0.4
       '@nuxt/opencollective': 0.3.3
-      '@nuxt/server': 2.15.8
-      '@nuxt/telemetry': 1.3.7
-      '@nuxt/utils': 2.15.8
-      '@nuxt/vue-app': 2.15.8
-      '@nuxt/vue-renderer': 2.15.8
-      '@nuxt/webpack': 2.15.8_vue@2.7.14
+      '@nuxt/server': 2.16.0
+      '@nuxt/telemetry': 1.4.1
+      '@nuxt/utils': 2.16.0
+      '@nuxt/vue-app': 2.16.0
+      '@nuxt/vue-renderer': 2.16.0
+      '@nuxt/webpack': 2.16.0
     transitivePeerDependencies:
       - '@vue/compiler-sfc'
       - arc-templates
@@ -10452,6 +10451,7 @@ packages:
       - babel-core
       - bluebird
       - bracket-template
+      - buffer
       - bufferutil
       - coffee-script
       - consola


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With the release of 2.16.0, we can move our recommendation for bridge to consume the normal (but latest) 2.x release, with the expectation that any patches we need for bridge can be released in the usual way.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

