### PR TITLE
fix: remove postcss8 option

### DIFF
--- a/packages/bridge/src/module.ts
+++ b/packages/bridge/src/module.ts
@@ -1,4 +1,3 @@
-import Module from 'module'
 import { defineNuxtModule, installModule, checkNuxtCompatibility } from '@nuxt/kit'
 import type { NuxtModule, NuxtCompatibility } from '@nuxt/schema'
 import type { BridgeConfig } from '../types'

--- a/packages/bridge/src/module.ts
+++ b/packages/bridge/src/module.ts
@@ -27,8 +27,6 @@ export default defineNuxtModule({
     imports: true,
     compatibility: true,
     meta: null,
-    // TODO: Remove from 2.16
-    postcss8: true,
     typescript: true,
     resolve: true
   } as BridgeConfig,
@@ -90,11 +88,6 @@ export default defineNuxtModule({
           await generateWebpackBuildManifest()
         }
       })
-    }
-    if (opts.postcss8) {
-      const _require = Module.createRequire(import.meta.url)
-      // @ts-expect-error TODO: legacy module container usage
-      nuxt.hook('modules:done', moduleContainer => installModule(_require('@nuxt/postcss8').bind(moduleContainer)))
     }
     if (opts.typescript) {
       await setupTypescript()


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves https://github.com/nuxt/bridge/issues/701
Should only be used with Nuxt 2.16+

I was thinking of disabling it by default but as the TODO comment said *remove*, I went with it. Happy to adapt though.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

