### PR TITLE
fix: Remove @nuxt/types from peerDependencies.

### DIFF
--- a/packages/bridge/build.config.ts
+++ b/packages/bridge/build.config.ts
@@ -7,7 +7,6 @@ export default defineBuildConfig({
     { input: 'src/runtime/', outDir: 'dist/runtime', format: 'esm', declaration: true }
   ],
   externals: [
-    '@nuxt/types',
     'webpack',
     'vite',
     'vue',

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -84,14 +84,6 @@
     "vue": "^2.7.14",
     "vue-router": "^3.6.5"
   },
-  "peerDependencies": {
-    "@nuxt/types": "^2.16.3"
-  },
-  "peerDependenciesMeta": {
-    "@nuxt/types": {
-      "optional": true
-    }
-  },
   "engines": {
     "node": "^14.16.0 || ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },

--- a/packages/bridge/src/runtime/app.ts
+++ b/packages/bridge/src/runtime/app.ts
@@ -1,9 +1,8 @@
-import type { Context as NuxtContext } from '@nuxt/types'
 import type { Hookable } from 'hookable'
 // @ts-ignore
 import type { Vue } from 'vue/types/vue'
 import type { ComponentOptions } from 'vue'
-import type { Route } from 'vue-router'
+import type { Nuxt2Context } from './nuxt2context'
 import { defineComponent, getCurrentInstance } from './composables'
 
 export const isVue2 = true
@@ -32,10 +31,6 @@ export interface RuntimeNuxtHooks {
   'app:mounted': (app: VueAppCompat) => void | Promise<void>
   'meta:register': (metaRenderers: any[]) => void | Promise<void>
   'vue:setup': () => void
-}
-
-export interface Nuxt2Context extends Omit<NuxtContext, 'from'> {
-  from: Route;
 }
 
 export interface NuxtAppCompat {

--- a/packages/bridge/src/runtime/capi.legacy.ts
+++ b/packages/bridge/src/runtime/capi.legacy.ts
@@ -2,7 +2,7 @@ import { defu } from 'defu'
 import { ComputedRef, computed, getCurrentInstance as getVM, isReactive, isRef, onBeforeMount, onServerPrefetch, reactive, ref, set, shallowRef, toRaw, toRefs, watch } from 'vue'
 import type { Route } from 'vue-router'
 import { useNuxtApp } from './app'
-import type { Nuxt2Context } from './app'
+import type { Nuxt2Context } from './nuxt2context'
 import { useRouter as _useRouter, useRoute as _useRoute, useState } from './composables'
 
 // Vue composition API export

--- a/packages/bridge/src/runtime/nuxt2context.d.ts
+++ b/packages/bridge/src/runtime/nuxt2context.d.ts
@@ -1,0 +1,92 @@
+import type { ServerResponse, IncomingMessage as HttpIncomingMessage } from 'node:http'
+import type { ComponentOptions } from 'vue'
+import type { Route } from 'vue-router'
+import type { NuxtAppCompat } from './app'
+
+export interface IncomingMessage extends HttpIncomingMessage {
+  originalUrl?: HttpIncomingMessage['url'] | undefined
+}
+
+export interface NuxtRuntimeConfig {
+  [key: string]: any
+  /**
+   * This is used internally by Nuxt for dynamic configuration and should not be used.
+   *
+   * @internal
+   */
+  _app?: never
+}
+
+export interface NuxtAppOptions extends ComponentOptions<Vue> {
+  nuxt: {
+    dateErr: number | null
+    err: any
+    error: any
+    defaultTransition?: any
+    transitions?: any[]
+    setTransitions?: (transitions: Transition | Transition[]) => void
+  }
+  head?: any
+  router: import('vue-router').default
+  context: Nuxt2Context
+  $_nuxtApp: NuxtAppCompat
+}
+
+type NuxtState = Record<string, any>
+
+export interface NuxtError {
+  message?: string
+  path?: string
+  statusCode?: number
+}
+
+export interface Nuxt2Context {
+  $config: NuxtRuntimeConfig
+  app: NuxtAppOptions
+  base: string
+  isDev: boolean
+  isHMR: boolean
+  route: Route
+  from: Route
+  store: any
+  env: Record<string, any>
+  params: Route['params']
+  payload: any
+  query: Route['query']
+  next?: (err?: any) => void
+  req: IncomingMessage
+  res: ServerResponse
+  redirect(status: number, path: string, query?: Route['query']): void
+  redirect(path: string, query?: Route['query']): void
+  redirect(location: Location): void
+  redirect(status: number, location: Location): void
+  ssrContext?: {
+    req: Nuxt2Context['req']
+    res: Nuxt2Context['res']
+    url: string
+    target: 'server' | 'static'
+    spa?: boolean
+    modern: boolean
+    runtimeConfig: {
+      public: NuxtRuntimeConfig
+      private: NuxtRuntimeConfig
+    }
+    redirected: boolean
+    next: (err?: any) => void
+    beforeRenderFns: Array<() => any>
+    beforeSerializeFns: Array<() => any>
+    fetchCounters: Record<string, number>
+    nuxt: {
+      layout: string
+      data: Array<Record<string, any>>
+      fetch: Array<Record<string, any>>
+      error: any
+      state: Array<Record<string, any>>
+      serverRendered: boolean
+      routePath: string
+      config: NuxtRuntimeConfig
+    }
+  }
+  error(params: NuxtError): NuxtError
+  nuxtState: NuxtState
+}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
https://github.com/nuxt/bridge/pull/749

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
In the following PR, the types for nuxt 2 context have been improved. To avoid dependency on nuxt 2 types, we want to move the necessary types from `@nuxt/types` and remove them from dependencies.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

