### PR TITLE
fix: use correct `extractCSS` type

### DIFF
--- a/packages/bridge-schema/build.config.ts
+++ b/packages/bridge-schema/build.config.ts
@@ -48,7 +48,7 @@ export default defineBuildConfig({
     'webpack-bundle-analyzer',
     'rollup-plugin-visualizer',
     'vite',
-    'mini-css-extract-plugin',
+    'extract-css-chunks-webpack-plugin',
     'terser-webpack-plugin',
     'css-minimizer-webpack-plugin',
     'webpack-dev-middleware',

--- a/packages/bridge-schema/src/config/build.ts
+++ b/packages/bridge-schema/src/config/build.ts
@@ -56,7 +56,7 @@ export default defineUntypedSchema({
 
     /**
      * Enables Common CSS Extraction using
-     * [Vue Server Renderer guidelines](https://ssr.vuejs.org/guide/css.html).
+     * [Vue Server Renderer guidelines](https://v2.ssr.vuejs.org/guide/css.html).
      *
      * Using [extract-css-chunks-webpack-plugin](https://github.com/faceyspacey/extract-css-chunks-webpack-plugin/) under the hood, your CSS will be extracted
      * into separate files, usually one per component. This allows caching your CSS and
@@ -100,6 +100,7 @@ export default defineUntypedSchema({
      *   }
      * }
      * ```
+     * @type {boolean | typeof import('extract-css-chunks-webpack-plugin').PluginOptions}
      */
     extractCSS: false,
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

Close #784

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Add `@type {boolean | typeof import('extract-css-chunks-webpack-plugin').PluginOptions}` in JSDoc and then `unbuild` will generate the correct type.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

