### PR TITLE
fix: generate templates based on middleware dir

### DIFF
--- a/packages/bridge/src/vite/templates.ts
+++ b/packages/bridge/src/vite/templates.ts
@@ -12,8 +12,9 @@ type TemplateContext = {
 // TODO: Use an alias
 export const middlewareTemplate = {
   filename: 'middleware.js',
-  getContents (ctx: TemplateContext) {
-    const { dir, router: { middleware }, srcDir } = ctx.nuxt.options
+  getContents ({ app, nuxt }: TemplateContext) {
+    const middleware = app.templateVars.middleware
+    const { dir, srcDir } = nuxt.options
     const _middleware = ((typeof middleware !== 'undefined' && middleware) || []).map((m) => {
       // Normalize string middleware
       if (typeof m === 'string') {

--- a/playground/middleware/inject-auth.js
+++ b/playground/middleware/inject-auth.js
@@ -1,0 +1,6 @@
+import { defineNuxtRouteMiddleware } from '#app'
+
+// TODO: `defineNuxtMiddleware` is not yet compatible with Nuxt3.
+export default defineNuxtRouteMiddleware(({ redirect }) => {
+  redirect('/auth')
+})

--- a/playground/pages/auth.vue
+++ b/playground/pages/auth.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <div>auth.vue</div>
+  </div>
+</template>

--- a/playground/pages/secret.vue
+++ b/playground/pages/secret.vue
@@ -1,0 +1,8 @@
+<template>
+  <div>navigate to auth</div>
+</template>
+<script lang="ts">
+export default defineComponent({
+  middleware: 'inject-auth'
+})
+</script>

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -89,6 +89,15 @@ describe('route rules', () => {
   })
 })
 
+describe('middleware', () => {
+  it('should navigate to auth', async () => {
+    const html = await $fetch('/secret')
+
+    expect(html).toContain('auth.vue')
+    expect(html).not.toContain('navigate to auth')
+  })
+})
+
 describe('dynamic paths', () => {
   if (process.env.NUXT_TEST_DEV) {
     // TODO:


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
https://github.com/nuxt/bridge/issues/468
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Generate template based on `middleware dir` since middleware is not recognized when created in `middleware dir` when generated from `router.middleware`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

