### PR TITLE
fix: convert `defineNuxtRouteMiddleware` to legacy middleware

### DIFF
--- a/packages/bridge/src/runtime/composables.ts
+++ b/packages/bridge/src/runtime/composables.ts
@@ -8,7 +8,7 @@ import { sendRedirect } from 'h3'
 import { defu } from 'defu'
 import { useRouter as useVueRouter, useRoute as useVueRoute } from 'vue-router/composables'
 import { hasProtocol, joinURL, parseURL } from 'ufo'
-import { useNuxtApp } from './app'
+import { useNuxtApp, callWithNuxt } from './app'
 
 export { useLazyAsyncData, refreshNuxtData } from './asyncData'
 export { useLazyFetch } from './fetch'
@@ -163,7 +163,7 @@ export interface AddRouteMiddlewareOptions {
 /** internal */
 function convertToLegacyMiddleware (middleware) {
   return async (ctx: any) => {
-    const result = await middleware(ctx.route, ctx.from)
+    const result = await callWithNuxt(ctx.$_nuxtApp, middleware, [ctx.route, ctx.from])
     if (result instanceof Error) {
       return ctx.error(result)
     }
@@ -245,7 +245,7 @@ export interface RouteMiddleware {
   (to: Route, from: Route): RouteMiddlewareReturn | Promise<RouteMiddlewareReturn>
 }
 
-export const defineNuxtRouteMiddleware = (middleware: RouteMiddleware) => middleware
+export const defineNuxtRouteMiddleware = (middleware: RouteMiddleware) => convertToLegacyMiddleware(middleware)
 
 interface AddRouteMiddleware {
   (name: string, middleware: RouteMiddleware, options?: AddRouteMiddlewareOptions): void

--- a/packages/bridge/src/runtime/composables.ts
+++ b/packages/bridge/src/runtime/composables.ts
@@ -9,6 +9,8 @@ import { defu } from 'defu'
 import { useRouter as useVueRouter, useRoute as useVueRoute } from 'vue-router/composables'
 import { hasProtocol, joinURL, parseURL } from 'ufo'
 import { useNuxtApp, callWithNuxt } from './app'
+import { createError, showError } from './error'
+import type { NuxtError } from './error'
 
 export { useLazyAsyncData, refreshNuxtData } from './asyncData'
 export { useLazyFetch } from './fetch'
@@ -163,7 +165,10 @@ export interface AddRouteMiddlewareOptions {
 /** internal */
 function convertToLegacyMiddleware (middleware) {
   return async (ctx: any) => {
+    // because the middleware is executed before the plugin
+    ctx.$_nuxtApp._processingMiddleware = true
     const result = await callWithNuxt(ctx.$_nuxtApp, middleware, [ctx.route, ctx.from])
+    delete ctx.$_nuxtApp._processingMiddleware
     if (result instanceof Error) {
       return ctx.error(result)
     }
@@ -229,14 +234,20 @@ export const navigateTo = (to: RawLocation | undefined | null, options?: Navigat
 }
 
 /** This will abort navigation within a Nuxt route middleware handler. */
-export const abortNavigation = (err?: Error | string) => {
+export const abortNavigation = (err?: string | Partial<NuxtError>) => {
   if (process.dev && !isProcessingMiddleware()) {
     throw new Error('abortNavigation() is only usable inside a route middleware handler.')
   }
-  if (err) {
-    throw err instanceof Error ? err : new Error(err)
+  if (!err) { return false }
+
+  err = createError(err)
+
+  if (err.fatal) {
+    const nuxtApp = useNuxtApp()
+    callWithNuxt(nuxtApp, showError, [err as NuxtError])
   }
-  return false
+
+  throw err
 }
 
 type RouteMiddlewareReturn = void | Error | string | Location | boolean

--- a/playground/middleware/redirect.ts
+++ b/playground/middleware/redirect.ts
@@ -1,0 +1,10 @@
+import { defineNuxtRouteMiddleware, navigateTo } from '#app'
+
+export default defineNuxtRouteMiddleware((to) => {
+  if (to.path === '/navigate-to-external') {
+    return navigateTo('/', { external: true })
+  }
+  if (to.path === '/redirect') {
+    return navigateTo('/navigation-target')
+  }
+})

--- a/playground/middleware/redirect.ts
+++ b/playground/middleware/redirect.ts
@@ -1,6 +1,12 @@
-import { defineNuxtRouteMiddleware, navigateTo } from '#app'
+import { defineNuxtRouteMiddleware, navigateTo, abortNavigation } from '#app'
 
 export default defineNuxtRouteMiddleware((to) => {
+  if ('abort' in to.query) {
+    return abortNavigation({
+      statusCode: 401,
+      fatal: true
+    })
+  }
   if (to.path === '/navigate-to-external') {
     return navigateTo('/', { external: true })
   }

--- a/playground/pages/navigate-to-external.vue
+++ b/playground/pages/navigate-to-external.vue
@@ -5,3 +5,8 @@
 <script setup>
 navigateTo('https://example.com/', { external: true })
 </script>
+<script>
+export default {
+  middleware: ['redirect']
+}
+</script>

--- a/playground/pages/redirect.vue
+++ b/playground/pages/redirect.vue
@@ -1,0 +1,8 @@
+<template>
+  <p>redirect.vue</p>
+</template>
+<script lang="ts">
+export default defineComponent({
+  middleware: ['redirect']
+})
+</script>

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -109,6 +109,15 @@ describe('middleware', () => {
     expect(headers.get('location')).toEqual('/')
     expect(status).toEqual(302)
   })
+
+  it('should allow aborting navigation on server-side', async () => {
+    const res = await fetch('/redirect?abort', {
+      headers: {
+        accept: 'application/json'
+      }
+    })
+    expect(res.status).toEqual(401)
+  })
 })
 
 describe('dynamic paths', () => {

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -96,6 +96,19 @@ describe('middleware', () => {
     expect(html).toContain('auth.vue')
     expect(html).not.toContain('navigate to auth')
   })
+
+  it('should redirect to navigation-target', async () => {
+    const html = await $fetch('/redirect')
+
+    expect(html).toContain('Navigated successfully')
+  })
+
+  it('should not overwrite headers', async () => {
+    const { headers, status } = await fetch('/navigate-to-external', { redirect: 'manual' })
+
+    expect(headers.get('location')).toEqual('/')
+    expect(status).toEqual(302)
+  })
 })
 
 describe('dynamic paths', () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Fixed `defineNuxtRouteMiddleware` as it needs to be converted to legacy middleware and executed.
Also, `abortNavigation` has been updated with reference to Nuxt 3.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

