### PR TITLE
Revert "feat: generate middleware types"

### DIFF
--- a/packages/bridge-schema/src/config/index.ts
+++ b/packages/bridge-schema/src/config/index.ts
@@ -1,3 +1,4 @@
+
 import app from './app'
 import build from './build'
 import cli from './cli'

--- a/packages/bridge/src/app.ts
+++ b/packages/bridge/src/app.ts
@@ -2,7 +2,7 @@ import { useNuxt, addTemplate, resolveAlias, addWebpackPlugin, addVitePlugin, ad
 import { NuxtModule } from '@nuxt/schema'
 import { normalize, resolve } from 'pathe'
 import { resolveImports } from 'mlly'
-import { componentsTypeTemplate, schemaTemplate, middlewareTypeTemplate } from './type-templates'
+import { componentsTypeTemplate, schemaTemplate } from './type-templates'
 import { distDir } from './dirs'
 import { VueCompat } from './vue-compat'
 
@@ -57,12 +57,8 @@ export async function setupAppBridge (_options: any) {
     ...componentsTypeTemplate,
     options: { components, buildDir: nuxt.options.buildDir }
   })
-
-  addTemplate(middlewareTypeTemplate)
-
   nuxt.hook('prepare:types', ({ references }) => {
     references.push({ path: resolve(nuxt.options.buildDir, 'types/components.d.ts') })
-    references.push({ path: resolve(nuxt.options.buildDir, 'types/middleware.d.ts') })
   })
 
   // Augment schema with module types

--- a/packages/bridge/src/runtime/app.ts
+++ b/packages/bridge/src/runtime/app.ts
@@ -1,3 +1,4 @@
+
 import type { NuxtAppCompat } from '@nuxt/bridge-schema'
 import { defineComponent, getCurrentInstance } from './composables'
 export const isVue2 = true

--- a/packages/bridge/src/type-templates.ts
+++ b/packages/bridge/src/type-templates.ts
@@ -1,3 +1,4 @@
+
 import { isAbsolute, relative, join } from 'pathe'
 import type { Component, Nuxt, NuxtApp } from '@nuxt/schema'
 import { genDynamicImport, genString } from 'knitwork'
@@ -7,11 +8,6 @@ import { resolveSchema, generateTypes } from 'untyped'
 type ComponentsTemplateOptions = {
   buildDir: string
   components: Component[]
-}
-
-interface TemplateContext {
-  nuxt: Nuxt
-  app: NuxtApp & { templateVars: Record<string, any> }
 }
 
 export const componentsTypeTemplate = {
@@ -32,22 +28,9 @@ export const componentNames: string[]
   }
 }
 
-export const middlewareTypeTemplate = {
-  filename: 'types/middleware.d.ts',
-  getContents: ({ app }: TemplateContext) => {
-    const middleware = app.templateVars.middleware
-
-    return [
-      'import type { NuxtAppCompat } from \'@nuxt/bridge-schema\'',
-      `export type MiddlewareKey = ${middleware.map(mw => genString(mw.name)).join(' | ') || 'string'}`,
-      'declare module \'vue/types/options\' {',
-      '  export type Middleware = MiddlewareKey | ((ctx: NuxtAppCompat, cb: Function) => Promise<void> | void)',
-      '  interface ComponentOptions<V extends Vue> {',
-      '    middleware?: Middleware | Middleware[]',
-      '  }',
-      '}'
-    ].join('\n')
-  }
+interface TemplateContext {
+  nuxt: Nuxt
+  app: NuxtApp
 }
 
 const adHocModules = ['router', 'pages', 'auto-imports', 'meta', 'components']


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
Reverts nuxt/bridge#796

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
When adding `named` middleware with `addRouteMiddleware`, the type is not generated, so revert it once.
(Even without this feature, I have no trouble migrating Nuxt 3.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

