### PR TITLE
fix: do not delete root

### DIFF
--- a/packages/bridge/src/vite/templates.ts
+++ b/packages/bridge/src/vite/templates.ts
@@ -57,6 +57,7 @@ const storeModules = ${genObjectFromRawEntries(_storeModules.map(m => [m.id, `$$
 export function createStore() {
   let store = normalizeRoot(storeModules.root || {})
   for (const id in storeModules) {
+    if (id === 'root') { continue }
     resolveStoreModules(store, storeModules[id], id)
   }
   if (typeof store === 'function') {

--- a/packages/bridge/src/vite/templates.ts
+++ b/packages/bridge/src/vite/templates.ts
@@ -56,7 +56,6 @@ const storeModules = ${genObjectFromRawEntries(_storeModules.map(m => [m.id, `$$
 
 export function createStore() {
   let store = normalizeRoot(storeModules.root || {})
-  delete storeModules.root
   for (const id in storeModules) {
     resolveStoreModules(store, storeModules[id], id)
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
resolve: https://github.com/nuxt/bridge/issues/847
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
I think this is happening because deleting `storeModules.root` causes `storeModules.root` to be empty when `createStore` is re-run.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

