### PR TITLE
fix: Use `Nuxt2Context` instead of `NuxtAppCompat`.

### DIFF
--- a/packages/bridge/src/type-templates.ts
+++ b/packages/bridge/src/type-templates.ts
@@ -38,10 +38,11 @@ export const middlewareTypeTemplate = {
     const middleware = app.templateVars.middleware
 
     return [
-      'import type { NuxtAppCompat } from \'@nuxt/bridge-schema\'',
+      'import type { Nuxt2Context } from \'@nuxt/bridge-schema\'',
+      'import type { ComponentOptions } from \'vue\'',
       `export type MiddlewareKey = ${middleware.map(mw => genString(mw.name)).join(' | ') || 'string'}`,
       'declare module \'vue/types/options\' {',
-      '  export type Middleware = MiddlewareKey | ((ctx: NuxtAppCompat, cb: Function) => Promise<void> | void)',
+      '  export type Middleware = MiddlewareKey | ((ctx: Nuxt2Context, cb: Function) => Promise<void> | void)',
       '  interface ComponentOptions<V extends Vue> {',
       '    middleware?: Middleware | Middleware[]',
       '  }',


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
It is more correct to use `Nuxt2Context` for nuxt 2 middleware.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

