### PR TITLE
fix: do not inject imports within `node_modules`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,28 @@ jobs:
       - name: Test (fixtures with dev)
         run: pnpm test:fixtures:webpack:dev
 
+  test-unit:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        node: [16]
+
+    steps:
+      - uses: actions/checkout@v3
+      - run: corepack enable
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Test (Unit)
+        run: pnpm test:unit
+
   build-release:
     permissions:
       id-token: write
@@ -130,6 +152,7 @@ jobs:
       - build
       - test-fixtures
       - test-fixtures-webpack
+      - test-unit
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test:fixtures": "pnpm dev:prepare && JITI_ESM_RESOLVE=1 vitest run --dir test",
     "test:fixtures:dev": "NUXT_TEST_DEV=true pnpm test:fixtures",
     "test:fixtures:webpack": "TEST_WITH_WEBPACK=1 pnpm test:fixtures",
-    "test:fixtures:webpack:dev": "TEST_WITH_WEBPACK=1 NUXT_TEST_DEV=true pnpm test:fixtures"
+    "test:fixtures:webpack:dev": "TEST_WITH_WEBPACK=1 NUXT_TEST_DEV=true pnpm test:fixtures",
+    "test:unit": "vitest run --dir packages"
   },
   "devDependencies": {
     "@nuxt/test-utils": "^3.6.5",

--- a/packages/bridge/src/imports/module.ts
+++ b/packages/bridge/src/imports/module.ts
@@ -18,6 +18,7 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
     imports: [],
     dirs: [],
     transform: {
+      include: [],
       exclude: undefined
     }
   },

--- a/packages/bridge/test/auto-imports.test.ts
+++ b/packages/bridge/test/auto-imports.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import * as VueFunctions from 'vue'
+import type { Import } from 'unimport'
+import { createUnimport } from 'unimport'
+import type { Plugin } from 'vite'
+import { TransformPlugin } from '../src/imports/transform'
+import { defaultPresets } from '../src/imports/presets'
+
+describe('imports:transform', () => {
+  const imports: Import[] = [
+    { name: 'ref', as: 'ref', from: 'vue' },
+    { name: 'computed', as: 'computed', from: 'bar' },
+    { name: 'foo', as: 'foo', from: 'excluded' }
+  ]
+
+  const ctx = createUnimport({
+    imports
+  })
+
+  const transformPlugin = TransformPlugin.raw({ ctx, options: { transform: { exclude: [/node_modules/] } } }, { framework: 'rollup' }) as Plugin
+  const transform = async (source: string) => {
+    const result = await (transformPlugin.transform! as Function).call({ error: null, warn: null } as any, source, '')
+    return typeof result === 'string' ? result : result?.code
+  }
+
+  it('should correct inject', async () => {
+    expect(await transform('const a = ref(0)')).toMatchInlineSnapshot('"import { ref } from \'vue\';\nconst a = ref(0)"')
+  })
+
+  it('should ignore existing imported', async () => {
+    expect(await transform('import { ref } from "foo"; const a = ref(0)')).to.equal(undefined)
+    expect(await transform('import { computed as ref } from "foo"; const a = ref(0)')).to.equal(undefined)
+    expect(await transform('import ref from "foo"; const a = ref(0)')).to.equal(undefined)
+    expect(await transform('import { z as ref } from "foo"; const a = ref(0)')).to.equal(undefined)
+    expect(await transform('let ref = () => {}; const a = ref(0)')).to.equal(undefined)
+    expect(await transform('let { ref } = Vue; const a = ref(0)')).to.equal(undefined)
+    expect(await transform('let [\ncomputed,\nref\n] = Vue; const a = ref(0); const b = ref(0)')).to.equal(undefined)
+  })
+
+  it('should ignore comments', async () => {
+    const result = await transform('// import { computed } from "foo"\n;const a = computed(0)')
+    expect(result).toMatchInlineSnapshot(`
+      "import { computed } from 'bar';
+      // import { computed } from \\"foo\\"
+      ;const a = computed(0)"
+    `)
+  })
+
+  it('should exclude files from transform', async () => {
+    expect(await transform('excluded')).toEqual(undefined)
+  })
+})
+
+const excludedVueHelpers = [
+  'mergeDefaults',
+  'version',
+  'warn',
+  'watchPostEffect',
+  'watchSyncEffect',
+  'set',
+  'del',
+  'default'
+]
+
+describe('imports:vue', () => {
+  for (const name of Object.keys(VueFunctions)) {
+    if (excludedVueHelpers.includes(name)) {
+      continue
+    }
+    it(`should register ${name} globally`, () => {
+      expect(defaultPresets.find(a => a.from === 'vue')!.imports).toContain(name)
+    })
+  }
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
Fixes: https://github.com/nuxt/bridge/issues/870
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
I have fixed it so that it throws an error if autoImport: false as in Nuxt 3.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

