### PR TITLE
fix: transpile unhead even when `meta: false` is set

### DIFF
--- a/packages/bridge/src/app.ts
+++ b/packages/bridge/src/app.ts
@@ -44,6 +44,9 @@ export async function setupAppBridge (_options: any) {
   // Transpile libs with modern syntax
   nuxt.options.build.transpile.push('h3', 'iron-webcrypto', 'ohash', 'ofetch')
 
+  // Transpile @unhead/vue and @unhead/ssr
+  nuxt.options.build.transpile.push('unhead')
+
   // Disable legacy fetch polyfills
   nuxt.options.fetch.server = false
   nuxt.options.fetch.client = false

--- a/packages/bridge/src/head.ts
+++ b/packages/bridge/src/head.ts
@@ -17,9 +17,6 @@ export default defineNuxtModule({
   setup (options, nuxt) {
     const runtimeDir = nuxt.options.alias['#head'] || resolve(distDir, 'head/runtime')
 
-    // Transpile @unhead/vue and @unhead/ssr
-    nuxt.options.build.transpile.push('unhead')
-
     // Add #head alias
     nuxt.options.alias['#head'] = runtimeDir
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
Fixes: https://github.com/nuxt/bridge/issues/876
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This occurs due to the effect of changing the `defineNuxtComponent` to use `useHead` at https://github.com/nuxt/bridge/pull/838.

Now it is only transpiled if meta: other than false, so meta: false will result in a build error.
I think that to enable bridge.head, bridge.app also needs to be enabled, so I moved it into `setupAppBridge`.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

