### PR TITLE
fix: remove `VueHeadMixin`

### DIFF
--- a/packages/bridge/src/head.ts
+++ b/packages/bridge/src/head.ts
@@ -61,9 +61,6 @@ export default defineNuxtModule({
       ]
     })
 
-    // Add generic plugin
-    addPlugin({ src: resolve(runtimeDir, 'plugin') })
-
     // Add library-specific plugin
     addPlugin({ src: resolve(runtimeDir, 'plugins/unhead') })
   }

--- a/packages/bridge/src/runtime/head/plugin.ts
+++ b/packages/bridge/src/runtime/head/plugin.ts
@@ -1,6 +1,0 @@
-import { VueHeadMixin } from '@unhead/vue'
-import { defineNuxtPlugin } from '../app'
-
-export default defineNuxtPlugin((nuxtApp) => {
-  nuxtApp.vueApp.mixin(VueHeadMixin)
-})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
Fixes: https://github.com/nuxt/bridge/issues/884
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Nuxt Bridge does not use `VueHeadMixin`, so it is not necessary.
The error occurs when upgrading to `@unhead/vue@1.3.5` because it was using `VueHeadMixin`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

