### PR TITLE
feat: generate `tsconfig.json` when not using `nuxt/cli`

### DIFF
--- a/packages/bridge/src/module.ts
+++ b/packages/bridge/src/module.ts
@@ -1,4 +1,4 @@
-import { defineNuxtModule, installModule, checkNuxtCompatibility, logger } from '@nuxt/kit'
+import { defineNuxtModule, installModule, checkNuxtCompatibility, logger, writeTypes } from '@nuxt/kit'
 import type { NuxtModule, NuxtCompatibility } from '@nuxt/schema'
 import type { NodeMiddleware } from 'h3'
 import { fromNodeMiddleware } from 'h3'
@@ -118,6 +118,13 @@ export default defineNuxtModule({
     }
     if (opts.typescript) {
       await setupTypescript()
+
+      // support generating tsconfig by `nuxt dev` (for nuxt 2)
+      if (!opts.nitro) {
+        nuxt.hook('modules:done', async () => {
+          await writeTypes(nuxt)
+        })
+      }
     }
     if (opts.resolve) {
       setupBetterResolve()


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
`.nuxt/tsconfig.json` is only generated for the `nuxi` command.
Composables such as `useNuxtApp` can be used without migrating to the `nuxi` command.
I want to use `.nuxt/tsconfig.json` even when using such composables without using the `nuxi` command, so that I can generate it.
(I want to reduce the pain of setting up my own aliases such as `#imports`.)

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

