### PR TITLE
fix: add `nuxt2` command because it conflicts with nuxt/cli

### DIFF
--- a/packages/bridge/bin/nuxt2.cjs
+++ b/packages/bridge/bin/nuxt2.cjs
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+require('@nuxt/cli').run()
+  .catch((error) => {
+    require('consola').fatal(error)
+    require('exit')(2)
+  })

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -13,7 +13,8 @@
     "dist"
   ],
   "bin": {
-    "nuxi": "./bin/nuxt.mjs"
+    "nuxi": "./bin/nuxt.mjs",
+    "nuxt2": "./bin/nuxt2.cjs"
   },
   "scripts": {
     "build": "pnpm prepack",


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
Fixes: https://github.com/nuxt/bridge/issues/900
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
In nuxt/cli, `nuxt` is set for `bin` field.
This may conflict with the `nuxt` command in nuxt 2.
https://github.com/nuxt/cli/blob/master/package.json#L13-L17

To avoid conflicts with nuxt/cli, we would like to add a ~`nuxt-legacy`~ `nuxt2` command and make the nuxt 2 `nuxt` command available.

~If you have a better name than `nuxt-legacy`, I would like your advice.~

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

