### PR TITLE
fix: access `$store` from nuxt2Context

### DIFF
--- a/packages/bridge/src/runtime/app.plugin.mjs
+++ b/packages/bridge/src/runtime/app.plugin.mjs
@@ -99,6 +99,9 @@ export default async (ctx, inject) => {
 
   const proxiedApp = new Proxy(nuxtApp, {
     get (target, prop) {
+      if (prop === '$store') {
+        return target.nuxt2Context.store
+      }
       if (prop[0] === '$') {
         return target.nuxt2Context[prop] || target.vue2App?.[prop]
       }

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -29,7 +29,7 @@ export default defineNuxtConfig({
       })
     }
   ],
-  plugins: ['~/plugins/setup.js'],
+  plugins: ['~/plugins/setup.js', '~/plugins/store.js'],
   nitro: {
     routeRules: {
       '/route-rules/spa': { ssr: false }

--- a/playground/pages/store.vue
+++ b/playground/pages/store.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+const { $store } = useNuxtApp()
+
+const test = computed(() => $store.state.test)
+</script>
+
+<template>
+  <div>
+    <p>state is: {{ test }}</p>
+  </div>
+</template>

--- a/playground/plugins/store.js
+++ b/playground/plugins/store.js
@@ -1,0 +1,5 @@
+export default defineNuxtPlugin(() => {
+  const { $store } = useNuxtApp()
+
+  $store.commit('setTest', '✅')
+})

--- a/playground/store/index.js
+++ b/playground/store/index.js
@@ -7,3 +7,9 @@ export const actions = {
     state.test = '✅'
   }
 }
+
+export const mutations = {
+  setTest (state, value) {
+    state.test = value
+  }
+}

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -121,6 +121,11 @@ describe('legacy capi', () => {
     expect(html).toMatch(/([\s\S]*✅){11}/)
     await expectNoClientErrors('/legacy-capi')
   })
+
+  it('should be changed store.state', async () => {
+    const html = await $fetch('/legacy-capi')
+    expect(html).toContain('<tr><td><b>useStore</b></td><td> ✅</td></tr>')
+  })
 })
 
 describe('errors', () => {
@@ -188,6 +193,13 @@ describe('middleware', () => {
     const html = await $fetch('/add-route-middleware')
 
     expect(html).toContain('Navigated successfully')
+  })
+})
+
+describe('store', () => {
+  it('should be able to access $store in plugins', async () => {
+    const html = await $fetch('/store')
+    expect(html).toContain('state is: ✅')
   })
 })
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
Fixes: https://github.com/nuxt/bridge/issues/928

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
`vue2App` is undefined in defineNuxtPlugin.
So, vue2App.$store cannot be referenced.
Because `nuxt2Context.store` can also be accessed by defineNuxtPlugin, it was changed so that it is accessed from there.
(Adding `$store` to nuxt2Context did not work.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

