### PR TITLE
feat: add support for `definePageMeta`

### DIFF
--- a/packages/bridge/src/module.ts
+++ b/packages/bridge/src/module.ts
@@ -12,6 +12,7 @@ import { setupTypescript } from './typescript'
 import { setupMeta } from './meta'
 import { setupTranspile } from './transpile'
 import { generateWebpackBuildManifest } from './webpack/manifest'
+import pageMetaModule from './page-meta/module'
 
 export default defineNuxtModule({
   meta: {
@@ -29,7 +30,8 @@ export default defineNuxtModule({
     compatibility: true,
     meta: null,
     typescript: true,
-    resolve: true
+    resolve: true,
+    macros: false
   } as BridgeConfig,
   async setup (opts, nuxt) {
     // Disable if users explicitly set to false
@@ -70,6 +72,15 @@ export default defineNuxtModule({
         throw new Error('[bridge] Cannot enable composition-api with app disabled!')
       }
       await setupCAPIBridge(opts.capi === true ? {} : opts.capi)
+    }
+
+    if (opts.macros && opts.macros.pageMeta) {
+      // @ts-expect-error TODO: legacy module container usage
+      nuxt.hook('modules:done', moduleContainer =>
+        installModule(
+          pageMetaModule.bind(moduleContainer)
+        )
+      )
     }
 
     // Deprecate hooks

--- a/packages/bridge/src/page-meta/module.ts
+++ b/packages/bridge/src/page-meta/module.ts
@@ -1,0 +1,30 @@
+import { defineNuxtModule, addWebpackPlugin, addVitePlugin } from '@nuxt/kit'
+import { resolve } from 'pathe'
+import { distDir } from '../dirs'
+import { PageMetaPlugin } from './transform'
+import type { PageMetaPluginOptions } from './transform'
+
+export default defineNuxtModule({
+  meta: {
+    name: 'page-meta',
+    configKey: 'pageMeta'
+  },
+  setup (_, nuxt) {
+    const pageMetaOptions: PageMetaPluginOptions = {
+      sourcemap: true // nuxt.options.sourcemap not yet supported
+    }
+
+    addVitePlugin(PageMetaPlugin.vite(pageMetaOptions))
+    addWebpackPlugin(PageMetaPlugin.webpack(pageMetaOptions))
+
+    const runtimeDir = resolve(distDir, 'runtime')
+
+    nuxt.hook('imports:extend', (imports) => {
+      imports.push({
+        name: 'definePageMeta',
+        as: 'definePageMeta',
+        from: resolve(runtimeDir, 'page-meta/composables')
+      })
+    })
+  }
+})

--- a/packages/bridge/src/page-meta/transform.ts
+++ b/packages/bridge/src/page-meta/transform.ts
@@ -1,0 +1,193 @@
+import { pathToFileURL } from 'node:url'
+import { createUnplugin } from 'unplugin'
+import { parseQuery, parseURL } from 'ufo'
+import type {
+  CallExpression,
+  ExportDefaultDeclaration,
+  ObjectExpression,
+  Property,
+  VariableDeclaration
+} from 'estree'
+import type { Node } from 'estree-walker'
+import { walk } from 'estree-walker'
+import MagicString from 'magic-string'
+import { isAbsolute, normalize } from 'pathe'
+
+export interface PageMetaPluginOptions {
+  sourcemap?: boolean;
+}
+
+const NODE_MODULES_RE = /[\\/]node_modules[\\/]/
+const HAS_MACRO_RE = /\bdefinePageMeta\s*\(\s*/
+
+export const PageMetaPlugin = createUnplugin(
+  (options: PageMetaPluginOptions) => {
+    return {
+      name: 'nuxt:pages-macros-transform',
+      enforce: 'post',
+      transformInclude (id) {
+        const { pathname, search } = parseURL(
+          decodeURIComponent(pathToFileURL(id).href)
+        )
+        const { type, macro, setup } = parseQuery(search)
+
+        // vue files
+        if (
+          pathname.endsWith('.vue') &&
+          (type === 'template' ||
+            type === 'script' ||
+            setup === 'true' ||
+            macro ||
+            !search)
+        ) {
+          return true
+        }
+      },
+      transform (code, id) {
+        id = normalize(id)
+        const isNodeModule = NODE_MODULES_RE.test(id)
+
+        if (isNodeModule) {
+          return
+        }
+        const query = parseMacroQuery(id)
+        if (query.type && query.type !== 'script') {
+          return
+        }
+
+        const s = new MagicString(code)
+        function result () {
+          if (s.hasChanged()) {
+            return {
+              code: s.toString(),
+              map: options.sourcemap
+                ? s.generateMap({ hires: true })
+                : undefined
+            }
+          }
+        }
+
+        const hasMacro = HAS_MACRO_RE.test(code)
+
+        if (!hasMacro) {
+          return
+        }
+
+        walk(
+          this.parse(code, {
+            sourceType: 'module',
+            ecmaVersion: 'latest'
+          }) as Node,
+          {
+            enter (_node) {
+              if (
+                !['ExportDefaultDeclaration', 'VariableDeclaration'].includes(
+                  _node.type
+                )
+              ) {
+                return
+              }
+
+              const declaration = _node as ExportDefaultDeclaration & {
+                start: number;
+                end: number;
+              }
+
+              const callexprettison = getCallExpression(declaration)
+              if (
+                callexprettison.type !== 'CallExpression' ||
+                (callexprettison as CallExpression).callee.type !== 'Identifier'
+              ) {
+                return
+              }
+
+              const node = callexprettison as CallExpression & {
+                start: number;
+                end: number;
+              }
+              const name = 'name' in node.callee && node.callee.name
+
+              if (!name.includes('defineComponent')) {
+                return
+              }
+
+              const properties = (node.arguments[0] as ObjectExpression)
+                .properties as (Property & {
+                start: number;
+                end: number;
+              })[]
+
+              const setupNode = properties.find(
+                node =>
+                  node.key.type === 'Identifier' && node.key.name === 'setup'
+              )
+
+              if (!setupNode) {
+                return
+              }
+
+              let contents
+              walk(setupNode, {
+                enter (_node) {
+                  if (
+                    _node.type !== 'CallExpression' ||
+                    (_node as CallExpression).callee.type !== 'Identifier'
+                  ) {
+                    return
+                  }
+                  const node = _node as CallExpression & {
+                    start: number;
+                    end: number;
+                  }
+                  const name = 'name' in node.callee && node.callee.name
+
+                  if (name !== 'definePageMeta') {
+                    return
+                  }
+
+                  const meta = node.arguments[0] as ObjectExpression & {
+                    start: number;
+                    end: number;
+                  }
+
+                  contents = `const __nuxt_page_meta = 
+                    ${code.slice(meta.start, meta.end) || {}}
+                  `
+
+                  // remove macro
+                  s.overwrite(node.start, node.end, '')
+                }
+              })
+
+              s.prependLeft(declaration.start, contents)
+
+              if (code.includes('__nuxt_page_meta')) {
+                return
+              }
+
+              s.prependLeft(properties[0].start, '...__nuxt_page_meta,')
+            }
+          }
+        )
+
+        return result()
+      }
+    }
+  }
+)
+
+function getCallExpression (
+  node: ExportDefaultDeclaration | VariableDeclaration
+) {
+  if (node.type === 'ExportDefaultDeclaration') {
+    return node.declaration
+  }
+  return node.declarations[0].init
+}
+
+function parseMacroQuery (id: string) {
+  const { search } = parseURL(
+    decodeURIComponent(isAbsolute(id) ? pathToFileURL(id).href : id)
+  )
+  return parseQuery(search)
+}

--- a/packages/bridge/src/runtime/page-meta/composables.ts
+++ b/packages/bridge/src/runtime/page-meta/composables.ts
@@ -1,0 +1,21 @@
+import type { DefineComponent } from 'vue'
+
+export interface PageMeta {
+  name?: string;
+  middleware?: DefineComponent['middleware'];
+  layout?: DefineComponent['layout'];
+}
+
+const warnRuntimeUsage = (method: string) =>
+  console.warn(
+    `${method}() is a compiler-hint helper that is only usable inside ` +
+      'the script block of a single file component which is also a page. Its arguments should be ' +
+      'compiled away and passing it at runtime has no effect.'
+  )
+
+export const definePageMeta = (_: PageMeta): void => {
+  // @ts-ignore
+  if (process.dev) {
+    warnRuntimeUsage('definePageMeta')
+  }
+}

--- a/packages/bridge/types.d.ts
+++ b/packages/bridge/types.d.ts
@@ -41,6 +41,9 @@ export interface BridgeConfig {
   resolve: boolean
   typescript: boolean
   meta: boolean | null
+  macros: false | {
+    pageMeta: boolean
+  }
 }
 
 export interface NuxtConfig extends Nuxt2Config, Omit<_NuxtConfig, keyof Nuxt2Config> {

--- a/playground/layouts/custom.vue
+++ b/playground/layouts/custom.vue
@@ -1,0 +1,19 @@
+
+<script setup lang="ts">
+const count = ref(0)
+
+</script>
+
+<template>
+  <div>
+    Custom Layout:
+    <Nuxt />
+
+    <div class="count">
+      {{ count }}
+    </div>
+    <button class="add-count" @click="count++">
+      add count
+    </button>
+  </div>
+</template>

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -38,7 +38,10 @@ export default defineNuxtConfig({
   },
   bridge: {
     meta: true,
-    vite: !process.env.TEST_WITH_WEBPACK
+    vite: !process.env.TEST_WITH_WEBPACK,
+    macros: {
+      pageMeta: true
+    }
   },
   runtimeConfig: {
     secretKey: 'nuxt',

--- a/playground/pages/redirect.vue
+++ b/playground/pages/redirect.vue
@@ -1,8 +1,9 @@
-<template>
-  <p>redirect.vue</p>
-</template>
-<script lang="ts">
-export default defineComponent({
+<script setup lang="ts">
+definePageMeta({
   middleware: ['redirect']
 })
 </script>
+
+<template>
+  <p>redirect.vue</p>
+</template>

--- a/playground/pages/with-layout.vue
+++ b/playground/pages/with-layout.vue
@@ -1,0 +1,11 @@
+<script setup>
+definePageMeta({
+  layout: 'custom'
+})
+</script>
+
+<template>
+  <div>
+    <div>with-layout.vue</div>
+  </div>
+</template>

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -203,6 +203,15 @@ describe('store', () => {
   })
 })
 
+describe('layouts', () => {
+  it('should apply custom layout', async () => {
+    const html = await $fetch('/with-layout')
+
+    expect(html).toContain('with-layout.vue')
+    expect(html).toContain('Custom Layout:')
+  })
+})
+
 describe('nitro plugins', () => {
   it('should prepend a node to the rendered template', async () => {
     const html = await $fetch('/nitro/template-plugin')


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Add a module so that `definePageMeta` can also be used in Nuxt 2.
It is difficult to support other properties, so only `layout` and `middleware` will be supported first.

I have converted it as follows.

webpack

```ts
const __nuxt_page_meta = {
  layout: 'test'
}
export default /*#__PURE__*/_defineComponent({
  ...__nuxt_page_meta,
  __name: 'redirect',
  setup: function setup(__props) {
    return {
      __sfc: true
    };
  }
});
```

vite

```ts
const __nuxt_page_meta = {
  layout: "test"
}
const _sfc_main = /* @__PURE__ */ _defineComponent({
  ...__nuxt_page_meta,
  __name: "redirect",
  setup(__props) {
    return { __sfc: true };
  }
});
```

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

