### PR TITLE
fix: allow use with script tag

### DIFF
--- a/packages/bridge/src/page-meta/transform.ts
+++ b/packages/bridge/src/page-meta/transform.ts
@@ -114,7 +114,7 @@ export const PageMetaPlugin = createUnplugin(
               }
 
               const setupNode = properties.find(
-                node =>
+                node => node.key &&
                   node.key.type === 'Identifier' && node.key.name === 'setup'
               )
 

--- a/playground/pages/redirect.vue
+++ b/playground/pages/redirect.vue
@@ -4,6 +4,12 @@ definePageMeta({
 })
 </script>
 
+<script lang="ts">
+export default {
+  name: 'RedirectPage'
+}
+</script>
+
 <template>
   <p>redirect.vue</p>
 </template>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
Fixes: https://github.com/nuxt/bridge/issues/952
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
When using `script setup` in Vue 2, there may be cases where the `script` tag is used in conjunction.
If `export default` is declared in `script`, then

```vue
<script setup>
definePageMeta({
  middleware: ['test']
})
</script>

<script>
export default {
  name: 'Test'
}
</script>
```

transformed(vite):
```js
const __default__ = {
  name: "Test"
}

export default /* @__PURE__ */ _defineComponent({
  ...__default__,
  setup(__props) {
    definePageMeta({
      middleware: ["test"]
    });
    return { __sfc: true };
  }
});
```

The content of `export default` is `SpreadElement` and there is no `key`.
So I fixed it to check if there is a `key` or not.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

