### PR TITLE
fix: added Handling for null init in VariableDeclarator

### DIFF
--- a/packages/bridge/src/page-meta/transform.ts
+++ b/packages/bridge/src/page-meta/transform.ts
@@ -98,6 +98,10 @@ export const PageMetaPlugin = createUnplugin(
 
               const declaration = getDeclaration(exportDeclaration)
 
+              if (!declaration) {
+                return
+              }
+
               const objectExpression = getObjectExpression(declaration)
 
               if (!objectExpression) {

--- a/playground/pages/with-layout.vue
+++ b/playground/pages/with-layout.vue
@@ -1,4 +1,13 @@
 <script setup>
+let message
+if (process.client) {
+  message = 'Client'
+} else if (process.server) {
+  message = 'Server'
+}
+
+console.log(message)
+
 definePageMeta({
   layout: 'custom'
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
I've added a process to return if the 'init' of 'VariableDeclarator' is null, as there are cases when it can be null.
We would like to avoid `walk` what we don't need, but it is currently difficult.

For example
```ts
let value

definePageMeta({
  layout: 'custom'
})
```
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

