### PR TITLE
perf: use granular imports for auto-importing composables

### DIFF
--- a/packages/bridge/src/app.ts
+++ b/packages/bridge/src/app.ts
@@ -11,7 +11,7 @@ export async function setupAppBridge (_options: any) {
   const nuxt = useNuxt()
 
   // Setup aliases
-  nuxt.options.alias['#app'] = resolve(distDir, 'runtime/index')
+  nuxt.options.alias['#app'] = resolve(distDir, 'runtime')
   nuxt.options.alias['nuxt3/app'] = nuxt.options.alias['#app']
   nuxt.options.alias['nuxt/app'] = nuxt.options.alias['#app']
   nuxt.options.alias['#build'] = nuxt.options.buildDir

--- a/packages/bridge/src/imports/presets.ts
+++ b/packages/bridge/src/imports/presets.ts
@@ -10,7 +10,7 @@ export const commonPresets: InlinePreset[] = [
   }),
   // vue-demi (mocked)
   defineUnimportPreset({
-    from: '#app',
+    from: '#app/app',
     imports: [
       'isVue2',
       'isVue3'
@@ -18,35 +18,36 @@ export const commonPresets: InlinePreset[] = [
   })
 ]
 
-export const appPreset = defineUnimportPreset({
-  from: '#app',
-  imports: [
-    'useLazyAsyncData',
-    'refreshNuxtData',
-    'defineNuxtComponent',
-    'useNuxtApp',
-    'defineNuxtPlugin',
-    'useRuntimeConfig',
-    'useState',
-    'useLazyFetch',
-    'useCookie',
-    'useRequestHeaders',
-    'useRequestEvent',
-    'useRouter',
-    'useRoute',
-    'defineNuxtRouteMiddleware',
-    'navigateTo',
-    'abortNavigation',
-    'addRouteMiddleware',
-    'useNuxt2Meta',
-    'clearError',
-    'createError',
-    'isNuxtError',
-    'throwError',
-    'showError',
-    'useError'
-  ]
-})
+const granularAppPresets: InlinePreset[] = [
+  {
+    imports: ['defineNuxtComponent', 'setNuxtAppInstance', 'useNuxtApp', 'defineNuxtPlugin'],
+    from: '#app/app'
+  },
+  {
+    imports: ['useRuntimeConfig', 'useNuxt2Meta', 'useRoute', 'useRouter', 'useState', 'abortNavigation', 'addRouteMiddleware', 'defineNuxtRouteMiddleware', 'navigateTo'],
+    from: '#app/composables'
+  },
+  {
+    imports: ['useLazyAsyncData', 'refreshNuxtData'],
+    from: '#app/asyncData'
+  },
+  {
+    imports: ['clearError', 'createError', 'isNuxtError', 'showError', 'useError', 'throwError'],
+    from: '#app/error'
+  },
+  {
+    imports: ['useLazyFetch'],
+    from: '#app/fetch'
+  },
+  {
+    imports: ['useCookie'],
+    from: '#app/cookie'
+  },
+  {
+    imports: ['useRequestHeaders', 'useRequestEvent'],
+    from: '#app/ssr'
+  }
+]
 
 export const vueKeys: Array<keyof typeof import('vue')> = [
   // Lifecycle
@@ -125,7 +126,7 @@ const vueRouterPreset = defineUnimportPreset({
 
 export const defaultPresets = [
   ...commonPresets,
-  appPreset,
+  ...granularAppPresets,
   vueRouterPreset,
   vuePreset
 ]

--- a/packages/bridge/src/runtime/app.plugin.mjs
+++ b/packages/bridge/src/runtime/app.plugin.mjs
@@ -1,6 +1,6 @@
 import Vue, { version } from 'vue'
 import { createHooks } from 'hookable'
-import { setNuxtAppInstance } from '#app'
+import { setNuxtAppInstance } from '#app/app'
 import { globalMiddleware } from '#build/global-middleware'
 
 // Reshape payload to match key `useLazyAsyncData` expects

--- a/packages/bridge/src/runtime/capi.plugin.mjs
+++ b/packages/bridge/src/runtime/capi.plugin.mjs
@@ -1,4 +1,4 @@
-import { defineNuxtPlugin } from '#app'
+import { defineNuxtPlugin } from '#imports'
 
 export default defineNuxtPlugin((nuxtApp) => {
   const _originalSetup = nuxtApp.nuxt2Context.app.setup

--- a/packages/bridge/src/runtime/nitro-bridge.server.mjs
+++ b/packages/bridge/src/runtime/nitro-bridge.server.mjs
@@ -1,4 +1,4 @@
-import { defineNuxtPlugin } from '#app'
+import { defineNuxtPlugin } from '#imports'
 
 const vueMetaRenderer = (nuxt) => {
   const meta = nuxt.ssrContext.meta.inject({

--- a/playground/middleware/redirect.ts
+++ b/playground/middleware/redirect.ts
@@ -1,4 +1,4 @@
-import { defineNuxtRouteMiddleware, abortNavigation } from '#app'
+import { defineNuxtRouteMiddleware, abortNavigation } from '#imports'
 
 export default defineNuxtRouteMiddleware((to) => {
   if ('abort' in to.query) {

--- a/playground/plugins/setup.js
+++ b/playground/plugins/setup.js
@@ -1,6 +1,6 @@
 import { onGlobalSetup, ref } from '@nuxtjs/composition-api'
 
-import { defineNuxtPlugin, addRouteMiddleware, navigateTo } from '#app'
+import { defineNuxtPlugin, addRouteMiddleware, navigateTo } from '#imports'
 
 export default defineNuxtPlugin(() => {
   const globalsetup = ref('🚧')


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
I would like to change to use granular imports as shown in the following improvement.
https://github.com/nuxt/nuxt/pull/23951

Refactoring of files is done in a separate PR.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

