### PR TITLE
feat!: port upstream `useLazyAsyncData`

### DIFF
--- a/packages/bridge/src/runtime/app.plugin.mjs
+++ b/packages/bridge/src/runtime/app.plugin.mjs
@@ -49,7 +49,11 @@ export default async (ctx, inject) => {
     provide: inject,
     globalName: 'nuxt',
     payload: proxiedState(process.client ? ctx.nuxtState : ctx.ssrContext.nuxt),
-    _asyncDataPromises: [],
+    _asyncDataPromises: {},
+    _asyncData: {},
+    static: {
+      data: {}
+    },
     isHydrating: true,
     nuxt2Context: ctx
   }

--- a/packages/bridge/src/runtime/composables/asyncData.ts
+++ b/packages/bridge/src/runtime/composables/asyncData.ts
@@ -135,7 +135,7 @@ export function useAsyncData<
 
   // Create or use a shared asyncData entity
   if (!nuxt._asyncData[key] || !options.immediate) {
-    nuxt.payload._errors[key] ??= null
+    nuxt.payload._errors[key] = nuxt.payload._errors[key] ?? null
 
     const _ref = options.deep ? ref : shallowRef
 

--- a/playground/pages/legacy/async-data.vue
+++ b/playground/pages/legacy/async-data.vue
@@ -2,6 +2,9 @@
   <div>
     <div>{{ hello }}</div>
     <NuxtChild />
+    <NuxtLink to="/legacy/setup">
+      to legacy setup
+    </NuxtLink>
   </div>
 </template>
 

--- a/playground/pages/legacy/setup.vue
+++ b/playground/pages/legacy/setup.vue
@@ -1,9 +1,11 @@
 <template>
   <div>
-    <div v-if="!pending">
-      {{ hello }}
-    </div>
+    <!-- eslint-disable-next-line vue/singleline-html-element-content-newline -->
+    <div v-if="!pending">{{ hello }}</div>
     <NuxtChild />
+    <NuxtLink to="/legacy/async-data">
+      to legacy async-data
+    </NuxtLink>
   </div>
 </template>
 
@@ -17,8 +19,10 @@ export default defineNuxtComponent({
       }
     })
 
+    const hello = computed(() => data.value?.hello)
+
     return {
-      hello: data.value?.hello,
+      hello,
       pending
     }
   }

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -95,7 +95,8 @@ describe('legacy async data', () => {
 
   it('should work with defineNuxtComponent and setup', async () => {
     const html = await $fetch('/legacy/setup')
-    expect(html).toContain('<div> Hello API </div>')
+    console.log(html)
+    expect(html).toContain('<div>Hello API</div>')
     const { script } = parseData(html)
     expect(Object.values(script._asyncData)).toMatchInlineSnapshot(`
       [

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -92,6 +92,19 @@ describe('legacy async data', () => {
       ]
     `)
   })
+
+  it('should work with defineNuxtComponent and setup', async () => {
+    const html = await $fetch('/legacy/setup')
+    expect(html).toContain('<div> Hello API </div>')
+    const { script } = parseData(html)
+    expect(Object.values(script._asyncData)).toMatchInlineSnapshot(`
+      [
+        {
+          "hello": "Hello API",
+        },
+      ]
+    `)
+  })
 })
 
 describe('navigate', () => {

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -95,7 +95,6 @@ describe('legacy async data', () => {
 
   it('should work with defineNuxtComponent and setup', async () => {
     const html = await $fetch('/legacy/setup')
-    console.log(html)
     expect(html).toContain('<div>Hello API</div>')
     const { script } = parseData(html)
     expect(Object.values(script._asyncData)).toMatchInlineSnapshot(`


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Port the `useLazyAsyncData` implementation from nuxt 3.

Breaking Changes
- remove `initialCache`
  - Payload cache won't be used when doing client-side navigation back to same page and fresh data will be fetched.

Feature
- support `immediate` and `deep` option
- returns `status` and `execute`
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

