### PR TITLE
fix: disable `#head` alias creation when `meta: false`

### DIFF
--- a/packages/bridge/src/head.ts
+++ b/packages/bridge/src/head.ts
@@ -61,6 +61,13 @@ export default defineNuxtModule({
       ]
     })
 
+    addImportsSources({
+      from: '#head',
+      imports: [
+        'useMeta'
+      ]
+    })
+
     // Add library-specific plugin
     addPlugin({ src: resolve(runtimeDir, 'plugins/unhead') })
   }

--- a/packages/bridge/src/imports/presets.ts
+++ b/packages/bridge/src/imports/presets.ts
@@ -1,13 +1,6 @@
 import { defineUnimportPreset, InlinePreset } from 'unimport'
 
 export const commonPresets: InlinePreset[] = [
-  // #head
-  defineUnimportPreset({
-    from: '#head',
-    imports: [
-      'useMeta'
-    ]
-  }),
   // vue-demi (mocked)
   defineUnimportPreset({
     from: '#app/app',


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
https://github.com/nuxt/bridge/issues/973
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
useMeta relies on useHead and assumes meta: true. Therefore, if meta: false, do not add an alias.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

