### PR TITLE
feat: `imports:context` hook for unimport context

### DIFF
--- a/packages/bridge/src/imports/module.ts
+++ b/packages/bridge/src/imports/module.ts
@@ -43,6 +43,8 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
       imports: options.imports
     })
 
+    await nuxt.callHook('imports:context', ctx)
+
     // composables/ dirs from all layers
     let composablesDirs = []
     for (const layer of nuxt.options._layers) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
I want to support the imports:context hook similar to Nuxt 3. If it goes well, nuxt-vitest might also be usable.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

