### PR TITLE
fix: typing legacy capi `defineComponent`

### DIFF
--- a/packages/bridge/src/runtime/capi.legacy.ts
+++ b/packages/bridge/src/runtime/capi.legacy.ts
@@ -1,5 +1,6 @@
 import { defu } from 'defu'
-import { type ComputedRef, computed, defineComponent as defineComponentVue, getCurrentInstance as getVM, isReactive, isRef, onBeforeMount, onServerPrefetch, reactive, ref, set, shallowRef, toRaw, toRefs, watch } from 'vue'
+import type { ComputedRef } from 'vue'
+import { computed, defineComponent as defineComponentVue, getCurrentInstance as getVM, isReactive, isRef, onBeforeMount, onServerPrefetch, reactive, ref, set, shallowRef, toRaw, toRefs, watch } from 'vue'
 import type { Route } from 'vue-router'
 import type { Nuxt2Context } from '@nuxt/bridge-schema'
 import { useNuxtApp } from './nuxt'

--- a/packages/bridge/src/runtime/capi.legacy.ts
+++ b/packages/bridge/src/runtime/capi.legacy.ts
@@ -1,5 +1,5 @@
 import { defu } from 'defu'
-import { ComputedRef, computed, defineComponent as defineComponentVue, getCurrentInstance as getVM, isReactive, isRef, onBeforeMount, onServerPrefetch, reactive, ref, set, shallowRef, toRaw, toRefs, watch } from 'vue'
+import { type ComputedRef, computed, defineComponent as defineComponentVue, getCurrentInstance as getVM, isReactive, isRef, onBeforeMount, onServerPrefetch, reactive, ref, set, shallowRef, toRaw, toRefs, watch } from 'vue'
 import type { Route } from 'vue-router'
 import type { Nuxt2Context } from '@nuxt/bridge-schema'
 import { useNuxtApp } from './nuxt'

--- a/packages/bridge/src/runtime/capi.legacy.ts
+++ b/packages/bridge/src/runtime/capi.legacy.ts
@@ -1,5 +1,5 @@
 import { defu } from 'defu'
-import { ComputedRef, computed, getCurrentInstance as getVM, isReactive, isRef, onBeforeMount, onServerPrefetch, reactive, ref, set, shallowRef, toRaw, toRefs, watch } from 'vue'
+import { ComputedRef, computed, defineComponent as defineComponentVue, getCurrentInstance as getVM, isReactive, isRef, onBeforeMount, onServerPrefetch, reactive, ref, set, shallowRef, toRaw, toRefs, watch } from 'vue'
 import type { Route } from 'vue-router'
 import type { Nuxt2Context } from '@nuxt/bridge-schema'
 import { useNuxtApp } from './nuxt'
@@ -217,7 +217,7 @@ const getHeadOptions = (options) => {
   return { head }
 }
 
-export const defineComponent = (options) => {
+export const defineComponent: typeof defineComponentVue = (options) => {
   if (!('head' in options)) { return options }
 
   return {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
#992 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
I have modified the return type definition of the `defineComponent` provided by @nuxtjs/composition-api of nuxt/bridge to match the one provided by Vue.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

