### PR TITLE
fix: `useRequestEvent` returns `H3Event `with disabled nitro

### DIFF
--- a/packages/bridge/src/runtime/composables/ssr.ts
+++ b/packages/bridge/src/runtime/composables/ssr.ts
@@ -1,6 +1,6 @@
 import type { H3Event } from 'h3'
 import type { NuxtAppCompat } from '@nuxt/bridge-schema'
-import { getRequestHeaders } from 'h3'
+import { getRequestHeaders, createEvent } from 'h3'
 import { useNuxtApp } from '../nuxt'
 
 export function useRequestHeaders<K extends string = string> (include: K[]): { [key in Lowercase<K>]?: string }
@@ -14,5 +14,6 @@ export function useRequestHeaders (include?: any[]) {
 }
 
 export function useRequestEvent (nuxtApp: NuxtAppCompat = useNuxtApp()): H3Event {
-  return nuxtApp.ssrContext?.event as H3Event
+  if (nuxtApp.ssrContext?.event) { return nuxtApp.ssrContext.event }
+  return createEvent(nuxtApp.ssrContext.req, nuxtApp.ssrContext.res)
 }

--- a/packages/bridge/src/runtime/composables/ssr.ts
+++ b/packages/bridge/src/runtime/composables/ssr.ts
@@ -15,5 +15,5 @@ export function useRequestHeaders (include?: any[]) {
 
 export function useRequestEvent (nuxtApp: NuxtAppCompat = useNuxtApp()): H3Event {
   if (nuxtApp.ssrContext?.event) { return nuxtApp.ssrContext.event }
-  return createEvent(nuxtApp.ssrContext.req, nuxtApp.ssrContext.res)
+  return createEvent(nuxtApp.ssrContext?.req, nuxtApp.ssrContext?.res)
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
Closes https://github.com/nuxt/bridge/issues/998
<!-- Please ensure there is an open issue and mention its number as #123 -->

This PR forces `useRequestEvent` function to create h3-compatible event (via `createEvent` utility from [h3](https://github.com/unjs/h3/blob/afc4183b513d517bbe83449f1a3dd5291f230e6c/src/event/event.ts#L118)). So, when nitro disabled, useRequestEvent will return constructed event from `nuxtApp.ssrContext.req` and `nuxtApp.ssrContext.res`

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

