### PR TITLE
fix: make errors returned by useLazyAsync reactive

### DIFF
--- a/packages/bridge/src/runtime/app.plugin.mjs
+++ b/packages/bridge/src/runtime/app.plugin.mjs
@@ -1,4 +1,4 @@
-import Vue, { version } from 'vue'
+import Vue, { version, reactive } from 'vue'
 import { createHooks } from 'hookable'
 import { setNuxtAppInstance } from '#app/nuxt'
 import { globalMiddleware } from '#build/global-middleware'
@@ -6,7 +6,7 @@ import { globalMiddleware } from '#build/global-middleware'
 // Reshape payload to match key `useLazyAsyncData` expects
 function proxiedState (state) {
   state._asyncData = state._asyncData || {}
-  state._errors = state._errors || {}
+  state._errors = state._errors || reactive({})
   return new Proxy(state, {
     get (target, prop) {
       if (prop === 'data') {

--- a/playground/pages/async-data.vue
+++ b/playground/pages/async-data.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+const { data: data1, error: error1 } = useLazyAsyncData('fetch-1', async () => {
+  const hello = await $fetch('/api/hello')
+  return {
+    hello
+  }
+})
+
+const { error: error2 } = useLazyAsyncData('fetch-2', () => {
+  throw new Error('fetch-2 error')
+})
+
+const { error: error3 } = useLazyAsyncData('fetch-3', () => {
+  throw new Error('fetch-3 error')
+})
+</script>
+
+<template>
+  <div>
+    <div>data1: {{ data1 }}</div>
+    <div>error1: {{ error1 }}</div>
+    <div>error2: {{ error2 }}</div>
+    <div>error3: {{ error3 }}</div>
+  </div>
+</template>

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -33,6 +33,12 @@ describe('nuxt composables', () => {
     const cookies = res.headers.get('set-cookie')
     expect(cookies).toMatchInlineSnapshot('"set-in-plugin=true; Path=/, set=set; Path=/, browser-set=set; Path=/, browser-set-to-null=; Max-Age=0; Path=/, browser-set-to-null-with-default=; Max-Age=0; Path=/"')
   })
+  it('error should be render', async () => {
+    const html = await $fetch('/async-data')
+
+    expect(html).toContain('error2: Error: fetch-2 error')
+    expect(html).toContain('error3: Error: fetch-3 error')
+  })
 })
 
 describe('head tags', () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
https://github.com/nuxt/bridge/issues/1001
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
The error returned by useLazyAsyncData remained null even if there was an error. (if ssr: false)
Fixed to behave the same as nuxt 3.
https://stackblitz.com/edit/github-drhhpj-bd1bnm

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

