### PR TITLE
ci: allow notification of upstream changes

### DIFF
--- a/.github/workflows/needs-port-upstream.yml
+++ b/.github/workflows/needs-port-upstream.yml
@@ -10,17 +10,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: get upstream pull request
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        id: set-result
-        with:
-          script: |
-            const { data } = await github.request('GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls', {
-              owner: 'nuxt',
-              repo: 'nuxt',
-              commit_sha: '${{ github.event.client_payload.sha }}',
-            })
-            return data[0].html_url
       - name: create issue
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
@@ -34,5 +23,5 @@ jobs:
               Please check the changes and port them.
 
               ## Pull Request
-              - ${{steps.set-result.outputs.result}}`,
+              - ${{github.event.client_payload.html_url}}`,
             })

--- a/.github/workflows/needs-port-upstream.yml
+++ b/.github/workflows/needs-port-upstream.yml
@@ -1,0 +1,38 @@
+name: needs port upstream
+on:
+  repository_dispatch:
+    types: [port-upstream]
+permissions:
+  issues: write
+jobs:
+  create-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: get upstream pull request
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        id: set-result
+        with:
+          script: |
+            const { data } = await github.request('GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls', {
+              owner: 'nuxt',
+              repo: 'nuxt',
+              commit_sha: '${{ github.event.client_payload.sha }}',
+            })
+            return data[0].html_url
+      - name: create issue
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            github.rest.issues.create({
+              owner: 'nuxt',
+              repo: 'bridge',
+              title: 'Need to port from upstream',
+              labels: ['upstream'],
+              body: `Upstream has been changed.
+              Please check the changes and port them.
+
+              ## Pull Request
+              - ${{steps.set-result.outputs.result}}`,
+            })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x]  🧹 Chore (updates to the build process or auxiliary tools and libraries)

### 📚 Description
The composables in nuxt/bridge are ported from nuxt 3.
So, if there are changes in nuxt 3, we need to follow the changes.
This PR notifies this repository of any modifications on the nuxt 3 side to reduce porting leaks.

Examples of Notification:
https://github.com/wattanx/repository-dispatch-target/issues/4

The notifier prepares the following workflow:
https://github.com/wattanx/repository-dispatch-owner/blob/main/.github/workflows/dispatch-update-file.yml


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

