### PR TITLE
fix: add compatibility with `hable`

### DIFF
--- a/packages/bridge/module.cjs
+++ b/packages/bridge/module.cjs
@@ -45,7 +45,13 @@ module.exports.defineNuxtConfig = (config = {}) => {
     nuxt.removeAllHooks ||= nuxt.clearHooks.bind(nuxt)
     nuxt.hookOnce ||= (name, fn, ...hookArgs) => {
       const unsub = nuxt.hook(name, (...args) => {
-        unsub()
+        if (typeof unsub === 'function') {
+          unsub()
+        } else {
+          // In hable@^3.0.0, the hook does not return a function.
+          nuxt.removeHook(name, fn)
+        }
+
         return fn(...args)
       }, ...hookArgs)
       return unsub


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
https://github.com/nuxt/bridge/issues/1000
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
In the case of `hable`, since the hook does not return a function, an error is output when executing `nuxt.callHook('restart')`.
```
unsub is not a function
```

In nuxt 2.17.3, it is migrated to hookable, so maybe this support is not needed.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

