### PR TITLE
fix: allow jsx/tsx  with webpack

### DIFF
--- a/packages/bridge/src/typescript.ts
+++ b/packages/bridge/src/typescript.ts
@@ -21,7 +21,7 @@ export function setupTypescript () {
   nuxt.options.build.babel.plugins.unshift(
     _require.resolve('@babel/plugin-proposal-optional-chaining'),
     _require.resolve('@babel/plugin-proposal-nullish-coalescing-operator'),
-    _require.resolve('@babel/plugin-transform-typescript')
+    [_require.resolve('@babel/plugin-transform-typescript'), { isTSX: true }]
   )
 
   extendWebpackConfig((config) => {

--- a/playground/components/JSX.jsx
+++ b/playground/components/JSX.jsx
@@ -1,0 +1,6 @@
+export default defineComponent({
+  name: 'JSX',
+  render () {
+    return <div>JSX component with jsx extention</div>
+  }
+})

--- a/playground/components/JsxComponent.vue
+++ b/playground/components/JsxComponent.vue
@@ -1,0 +1,7 @@
+<script lang="jsx">
+export default {
+  render () {
+    return <div class="container">JSX Component</div>
+  }
+}
+</script>

--- a/playground/pages/jsx.vue
+++ b/playground/pages/jsx.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    <JSX />
+    <JsxComponent />
+  </div>
+</template>
+
+<script setup>
+import JSX from '~/components/JSX'
+</script>

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -95,6 +95,12 @@ describe('pages', () => {
   it('uses server Vue build', async () => {
     expect(await $fetch('/')).toContain('Rendered on server: true')
   })
+  it('supports jsx', async () => {
+    const html = await $fetch('/jsx')
+
+    expect(html).toContain('JSX component')
+    expect(html).toContain('JSX component with jsx extention')
+  })
 })
 
 describe('legacy async data', () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
Fixes: https://github.com/nuxt/bridge/issues/17
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
`jsx` and `tsx` do not work when `typescript: true` is set.
I would like to add the `isTSX` option so that `tsx` and `jsx` will also work with webpack.
(I didn't write a test for `tsx` in nuxt2 because I thought there were few use cases using `tsx`.)

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

