### PR TITLE
fix: inject css in entry-legacy

### DIFF
--- a/packages/bridge/src/vite/manifest.ts
+++ b/packages/bridge/src/vite/manifest.ts
@@ -80,11 +80,14 @@ export async function generateBuildManifest (ctx: ViteBuildContext) {
   for (const entry in clientManifest) {
     if (!clientManifest[entry].file.startsWith('polyfills-legacy') && clientManifest[entry].file.includes('-legacy')) {
       clientImports.add(clientManifest[entry].file)
-      for (const key of ['css', 'assets', 'dynamicImports']) {
+      for (const key of ['assets', 'dynamicImports']) {
         for (const file of clientManifest[entry][key] || []) {
           clientEntry[key].add(file)
         }
       }
+    }
+    for (const file of clientManifest[entry].css || []) {
+      clientEntry.css.add(file)
     }
     delete clientManifest[entry].isEntry
   }

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -291,11 +291,12 @@ describe('dynamic paths', () => {
     await expectNoClientErrors('/assets')
   })
 
-  // Vite legacy build does not emit CSS files
-  it.skipIf(!process.env.TEST_WITH_WEBPACK)('adds relative paths to CSS', async () => {
+  // webpack injects CSS differently
+  it('adds relative paths to CSS', async () => {
     const html = await $fetch('/assets')
-    const urls = Array.from(html.matchAll(/(href|src)="(.*?)"/g)).map(m => m[2])
+    const urls = Array.from(html.matchAll(/(href|src)="(.*?)"|url\(([^)]*?)\)/g)).map(m => m[2] || m[3])
     const cssURL = urls.find(u => /_nuxt\/assets.*\.css$/.test(u))
+    expect(cssURL).toBeDefined()
     const css = await $fetch(cssURL)
     const imageUrls = Array.from(css.matchAll(/url\(['"]?([^')]*)['"]?\)/g)).map(m =>
       m[1].replace(/[-.][\w]{8}\./g, '.')


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
Fixes: https://github.com/nuxt/bridge/issues/561
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
In the case of `nuxi build` with `vite` mode, no css was inserted. Because `css` in `entry-legacy` is empty.
This fix inserts the file in `css` in `entry-legacy`.

before
```js
// client.manifest.mjs
export default {
  "entry-legacy.f8ccdd6e.js": {
      ...,
      "css": [],
  }
}
```

after
```js
// client.manifest.mjs
export default {
  "entry-legacy.f8ccdd6e.js": {
      ...,
      "css": [
        "client-T5UAGipt.css",
        "assets-757buapP.css"
    ],
  }
}
```

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

