### PR TITLE
fix: change isTSX option to opt-in

### DIFF
--- a/packages/bridge/src/module.ts
+++ b/packages/bridge/src/module.ts
@@ -131,7 +131,7 @@ export default defineNuxtModule({
       })
     }
     if (opts.typescript) {
-      await setupTypescript()
+      await setupTypescript({ isTSX: typeof opts.typescript === 'object' && opts.typescript.isTSX })
 
       // support generating tsconfig by `nuxt dev` (for nuxt 2)
       if (!opts.nitro) {

--- a/packages/bridge/src/typescript.ts
+++ b/packages/bridge/src/typescript.ts
@@ -4,7 +4,11 @@ import { extendWebpackConfig, useNuxt } from '@nuxt/kit'
 const extensions = ['ts', 'tsx', 'cts', 'mts']
 const typescriptRE = /\.[cm]?tsx?$/
 
-export function setupTypescript () {
+type SetupTypescriptOptions = {
+  isTSX: boolean;
+}
+
+export function setupTypescript ({ isTSX }: SetupTypescriptOptions) {
   const nuxt = useNuxt()
 
   nuxt.options.extensions.push(...extensions)
@@ -21,7 +25,7 @@ export function setupTypescript () {
   nuxt.options.build.babel.plugins.unshift(
     _require.resolve('@babel/plugin-proposal-optional-chaining'),
     _require.resolve('@babel/plugin-proposal-nullish-coalescing-operator'),
-    [_require.resolve('@babel/plugin-transform-typescript'), { isTSX: true }]
+    [_require.resolve('@babel/plugin-transform-typescript'), { isTSX }]
   )
 
   extendWebpackConfig((config) => {

--- a/packages/bridge/types.d.ts
+++ b/packages/bridge/types.d.ts
@@ -39,7 +39,9 @@ export interface BridgeConfig {
   compatibility: boolean
   postcss8: boolean
   resolve: boolean
-  typescript: boolean
+  typescript: boolean | {
+    isTSX?: boolean
+  }
   meta: boolean | null
   macros: false | {
     pageMeta: boolean

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -14,7 +14,9 @@ const bridgeConfig = {
   nitroGenerator: process.env.TEST_NITRO_GENERATOR !== 'false',
   imports: process.env.TEST_IMPORTS !== 'false',
   meta: process.env.TEST_META !== 'false',
-  typescript: process.env.TEST_TYPESCRIPT !== 'false',
+  typescript: {
+    isTSX: true
+  },
   macros: {
     pageMeta: true
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
Fixes: https://github.com/nuxt/bridge/issues/1063
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
If you add `isTSX`, you cannot use `angle-bracket syntax`.
We would like to change it to opt-in as it would be inconvenient for users who do not use `tsx`.

(If it were possible to replace `esbuild`, I would replace it.)

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

