### PR TITLE
fix: prevent duplicate manifest generation

### DIFF
--- a/packages/bridge/src/nitro.ts
+++ b/packages/bridge/src/nitro.ts
@@ -244,7 +244,7 @@ export async function setupNitroBridge () {
       const jsServerEntry = resolve(nuxt.options.buildDir, 'dist/server/server.js')
       await fsp.writeFile(jsServerEntry.replace(/.js$/, '.cjs'), 'module.exports = require("./server.js")', 'utf8')
       await fsp.writeFile(jsServerEntry.replace(/.js$/, '.mjs'), 'export { default } from "./server.cjs"', 'utf8')
-    } else if (name === 'client') {
+    } else if (name === 'client' && nuxt.options.dev) {
       const manifest = await fsp.readFile(resolve(nuxt.options.buildDir, 'dist/server/client.manifest.json'), 'utf8')
       await fsp.writeFile(resolve(nuxt.options.buildDir, 'dist/server/client.manifest.mjs'), 'export default ' + JSON.stringify(normalizeWebpackManifest(JSON.parse(manifest)), null, 2), 'utf8')
     }

--- a/packages/bridge/src/vite/manifest.ts
+++ b/packages/bridge/src/vite/manifest.ts
@@ -144,8 +144,8 @@ export async function generateDevSSRManifest (ctx: ViteBuildContext, css: string
 
 export async function writeClientManifest (clientManifest: any, buildDir: string) {
   const clientManifestJSON = JSON.stringify(clientManifest, null, 2)
-  await fse.writeFile(resolve(buildDir, 'dist/server/client.manifest.json'), clientManifestJSON, 'utf-8')
-  await fse.writeFile(resolve(buildDir, 'dist/server/client.manifest.mjs'), `export default ${clientManifestJSON}`, 'utf-8')
+  await fse.writeFile(resolve(buildDir, 'dist/server/client.manifest.json'), clientManifestJSON, 'utf8')
+  await fse.writeFile(resolve(buildDir, 'dist/server/client.manifest.mjs'), `export default ${clientManifestJSON}`, 'utf8')
 }
 
 export async function writeManifest (ctx: ViteBuildContext, css: string[] = []) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
I want to avoid duplicate generation of client.manifest.
In the case of a webpack production build, the manifest is generated in the following two places:

https://github.com/nuxt/bridge/blob/cffcd070e81477eef6623ac65cbe03ca4a36796e/packages/bridge/src/module.ts#L128-L130

https://github.com/nuxt/bridge/blob/cffcd070e81477eef6623ac65cbe03ca4a36796e/packages/bridge/src/nitro.ts#L241-L251

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

