### PR TITLE
fix: in the browser, `useRequestEvent` return undefined

### DIFF
--- a/packages/bridge/src/runtime/composables/cookie.ts
+++ b/packages/bridge/src/runtime/composables/cookie.ts
@@ -95,9 +95,10 @@ export function useCookie<T = string | null | undefined> (name: string, _opts?: 
     const nuxtApp = useNuxtApp()
     const writeFinalCookieValue = () => {
       if (opts.readonly || isEqual(cookie.value, cookies[name])) { return }
-      writeServerCookie(useRequestEvent(nuxtApp), name, cookie.value, opts as CookieOptions<any>)
+      writeServerCookie(useRequestEvent(nuxtApp)!, name, cookie.value, opts as CookieOptions<any>)
     }
 
+    // @ts-expect-error
     const unhook = nuxtApp.hooks.hookOnce('app:rendered', writeFinalCookieValue)
     nuxtApp.hooks.hookOnce('app:error', () => {
       unhook() // don't write cookie subsequently when app:rendered is called
@@ -110,7 +111,7 @@ export function useCookie<T = string | null | undefined> (name: string, _opts?: 
 
 function readRawCookies (opts: CookieOptions = {}): Record<string, string> {
   if (process.server) {
-    return parse(getRequestHeader(useRequestEvent(), 'cookie') || '', opts)
+    return parse(getRequestHeader(useRequestEvent()!, 'cookie') || '', opts)
   } else if (process.client) {
     return parse(document.cookie, opts)
   }

--- a/packages/bridge/src/runtime/composables/ssr.ts
+++ b/packages/bridge/src/runtime/composables/ssr.ts
@@ -14,7 +14,7 @@ export function useRequestHeaders (include?: any[]) {
 }
 
 export function useRequestEvent (nuxtApp: NuxtAppCompat = useNuxtApp()): H3Event | undefined {
-  if (!nuxtApp.ssrContext) {
+  if (process.client || !nuxtApp.ssrContext) {
     return undefined
   }
   // check if H3 event is available

--- a/packages/bridge/src/runtime/composables/ssr.ts
+++ b/packages/bridge/src/runtime/composables/ssr.ts
@@ -13,7 +13,10 @@ export function useRequestHeaders (include?: any[]) {
   return Object.fromEntries(include.map(key => key.toLowerCase()).filter(key => headers[key]).map(key => [key, headers[key]]))
 }
 
-export function useRequestEvent (nuxtApp: NuxtAppCompat = useNuxtApp()): H3Event {
+export function useRequestEvent (nuxtApp: NuxtAppCompat = useNuxtApp()): H3Event | undefined {
+  if (!nuxtApp.ssrContext) {
+    return undefined
+  }
   // check if H3 event is available
   if (nuxtApp.ssrContext?.event) { return nuxtApp.ssrContext.event }
   // Check if we created H3 event manually before


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
Fixes: https://github.com/nuxt/bridge/issues/1088

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
In Nuxt 3 `useRequestEvent` returns `undefined` in browser's case.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

