### PR TITLE
fix: ignore CallExpression other than `defineComponent`

### DIFF
--- a/packages/bridge/src/page-meta/transform.ts
+++ b/packages/bridge/src/page-meta/transform.ts
@@ -198,6 +198,9 @@ function getObjectExpression (node: Node) {
 
   // ts and webpack
   if (node.type === 'CallExpression') {
+    if (node.callee.type === 'Identifier' && !node.callee.name.includes('defineComponent')) {
+      return
+    }
     if (node.arguments[0].type === 'CallExpression') {
       const callexpression = node.arguments[0]
       return callexpression.arguments.find(arg => arg.type === 'ObjectExpression' && arg.properties.length > 0) as ObjectExpression

--- a/packages/bridge/test/page-meta.test.ts
+++ b/packages/bridge/test/page-meta.test.ts
@@ -36,6 +36,7 @@ import { defineComponent as _defineComponent } from 'vue';
 export default /*#__PURE__*/_defineComponent({
   __name: 'redirect',
   setup: function setup(__props) {
+    const route = useRoute()
     definePageMeta({
       middleware: ['redirect'],
       layout: 'custom'
@@ -53,6 +54,7 @@ export default /*#__PURE__*/_defineComponent({
   export default /*#__PURE__*/_defineComponent({
     ...__nuxt_page_meta,__name: 'redirect',
     setup: function setup(__props) {
+      const route = useRoute()
       ;
       return {
         __sfc: true


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
Fixes: https://github.com/nuxt/bridge/issues/1108
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
If there are function calls in addition to definePageMeta, an error may occur.
(without arguments such as `const route = useRoute()`)

For `typescript` and `webpack`, since what's needed for the process is `defineComponent`, I have made corrections to only process the CallExpression of `defineComponent`.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

