### PR TITLE
fix: align `error` param in `showError`/`createError` with H3

### DIFF
--- a/packages/bridge/src/runtime/composables/error.ts
+++ b/packages/bridge/src/runtime/composables/error.ts
@@ -4,9 +4,14 @@ import { useNuxtApp } from '../nuxt'
 
 export const useError = () => toRef(useNuxtApp().payload, 'error')
 
-export interface NuxtError extends H3Error {}
+export interface NuxtError<DataT = unknown> extends H3Error<DataT> {}
 
-export const showError = (_err: string | Error | Partial<NuxtError>) => {
+export const showError = <DataT = unknown>(
+  _err: string | Error | (Partial<NuxtError<DataT>> & {
+    status?: number;
+    statusText?: string;
+  })
+) => {
   const err = createError(_err)
 
   try {
@@ -36,7 +41,12 @@ export const clearError = async (options: { redirect?: string } = {}) => {
 
 export const isNuxtError = (err?: string | object): err is NuxtError => !!(err && typeof err === 'object' && ('__nuxt_error' in err))
 
-export const createError = (err: string | Partial<NuxtError>): NuxtError => {
+export const createError = <DataT = unknown>(
+  err: string | Error | (Partial<NuxtError<DataT>> & {
+    status?: number;
+    statusText?: string;
+  })
+): NuxtError => {
   const _err: NuxtError = _createError(err)
     ; (_err as any).__nuxt_error = true
   return _err


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
Fixes: https://github.com/nuxt/bridge/issues/1120
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Aligns error param of Nuxt's showError and createError with H3's as in upstream.


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

