### PR TITLE
feat: add option to not use `@vitejs/plugin-legacy`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
         compatibility: ['compatibility', 'no-compatibility']
         resolve: ['resolve', 'no-resolve']
         typescript: ['isTSX', 'esbuild']
+        vite-legacy: ['legacy', 'no-legacy']
         exclude:
           - transpile: 'no-transpile'
             builder: 'vite'
@@ -92,6 +93,8 @@ jobs:
             builder: 'vite'
           - compatibility: 'no-compatibility'
             env: 'dev'
+          - vite-legacy: 'no-legacy'
+            builder: 'webpack'
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -135,6 +138,7 @@ jobs:
         env:
           TEST_ENV: ${{ matrix.env }}
           TEST_BUILDER: ${{ matrix.builder }}
+          TEST_VITE_LEGACY: ${{ matrix.vite-legacy || 'legacy' }}
           TEST_TRANSPILE: ${{ matrix.transpile || 'transpile' }}
           TEST_COMPATIBILITY: ${{ matrix.compatibility || 'compatibility' }}
           TEST_RESOLVE: ${{ matrix.resolve || 'resolve' }}

--- a/packages/bridge/src/vite/stub-legacy.cjs
+++ b/packages/bridge/src/vite/stub-legacy.cjs
@@ -1,3 +1,0 @@
-// CommonJS proxy to bypass jiti transforms from nuxt 2
-/** @type {typeof import('@vitejs/plugin-legacy')['default'] } */
-module.exports = require('@vitejs/plugin-legacy')

--- a/packages/bridge/types.d.ts
+++ b/packages/bridge/types.d.ts
@@ -23,7 +23,12 @@ export interface NuxtSSRContext extends SSRContext {
 export interface BridgeConfig {
   nitro: boolean
   nitroGenerator: boolean
-  vite: boolean
+  vite: boolean | {
+    /**
+     * If set to false, `@vitejs/plugin-legacy` not used.
+     */
+    legacy?: boolean
+  }
   app: boolean | {}
   capi: boolean | {
     legacy?: boolean

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -5,7 +5,7 @@ import { defineNuxtConfig } from '@nuxt/bridge'
 global.__NUXT_PREPATHS__ = (global.__NUXT_PREPATHS__ || []).concat(__dirname)
 
 const bridgeConfig = {
-  vite: process.env.TEST_BUILDER !== 'webpack',
+  vite: process.env.TEST_BUILDER !== 'webpack' ? { legacy: process.env.TEST_VITE_LEGACY !== 'no-legacy' } : false,
   transpile: process.env.TEST_TRANSPILE !== 'no-transpile',
   compatibility: process.env.TEST_COMPATIBILITY !== 'no-compatibility',
   resolve: process.env.TEST_RESOLVE !== 'no-resolve',


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
Fixes: https://github.com/nuxt/bridge/issues/1126

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
I want to add an option not to use `@vitejs/plugin-legacy.` 
I believe that having the option not to use `@vitejs/plugin-legacy` would make it easier to migrate to Nuxt 3 using vite mode.
(I think it will be a big change, so I decided to opt-in.)

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

