### PR TITLE
fix: use the `route` and `from` in beforeEach

### DIFF
--- a/packages/bridge/src/runtime/app.plugin.mjs
+++ b/packages/bridge/src/runtime/app.plugin.mjs
@@ -73,7 +73,7 @@ export default async (ctx, inject) => {
     nuxtApp._processingMiddleware = true
 
     for (const middleware of nuxtApp._middleware.global) {
-      const result = await middleware(ctx)
+      const result = await middleware({ ...ctx, route: to, from })
       if (result || result === false) { return next(result) }
     }
 

--- a/playground/middleware/redirect.global.ts
+++ b/playground/middleware/redirect.global.ts
@@ -1,6 +1,10 @@
 import { withoutTrailingSlash } from 'ufo'
 
-export default defineNuxtRouteMiddleware((to) => {
+export default defineNuxtRouteMiddleware((to, from) => {
+  if (process.client) {
+    console.info('[middleware] to', to)
+    console.info('[middleware] from', from)
+  }
   if (useRequestHeaders(['trailing-slash'])['trailing-slash'] && to.fullPath.endsWith('/')) {
     return navigateTo(withoutTrailingSlash(to.fullPath), { redirectCode: 307 })
   }

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -7,6 +7,17 @@
       </button>
     </div>
     Rendered on server: {{ serverBuild }}
+
+    <section class="links-container">
+      <h2>Links</h2>
+      <ul>
+        <li>
+          <NuxtLink to="/legacy-capi">
+            legacy-capi
+          </NuxtLink>
+        </li>
+      </ul>
+    </section>
   </div>
 </template>
 
@@ -18,3 +29,16 @@ state.value = '123'
 const updateState = () => { state.value = '456' }
 const serverBuild = useState('server-build', () => getCurrentInstance().proxy.$isServer)
 </script>
+
+<style scoped>
+.links-container {
+  padding: 8px 0;
+
+}
+.links-container h2 {
+  margin: 8px 0;
+}
+.links-container ul {
+  padding-inline-start: 24px;
+}
+</style>

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -284,6 +284,34 @@ describe('middleware', () => {
 
     expect(html).toContain('Navigated successfully')
   })
+
+  // if `no-resolve`, an error occurs at `useRoute`.
+  it.skipIf(isWebpack && isNoResolve)('should be output with target as to and origin as from', async () => {
+    const { page, consoleLogs } = await renderPage('/')
+    await page.getByRole('link').click()
+
+    const logs = consoleLogs.filter(i => i.type === 'info' && i.text.includes('[middleware]'))
+    expect(logs).toMatchInlineSnapshot(`
+      [
+        {
+          "text": "[middleware] to {name: index, meta: Object, path: /, hash: , query: Object}",
+          "type": "info",
+        },
+        {
+          "text": "[middleware] from {name: null, meta: Object, path: /, hash: , query: Object}",
+          "type": "info",
+        },
+        {
+          "text": "[middleware] to {name: legacy-capi, meta: Object, path: /legacy-capi, hash: , query: Object}",
+          "type": "info",
+        },
+        {
+          "text": "[middleware] from {name: index, meta: Object, path: /, hash: , query: Object}",
+          "type": "info",
+        },
+      ]
+    `)
+  })
 })
 
 describe('navigate', () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
Fixes: https://github.com/nuxt/bridge/issues/1134
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
I think this problem is caused by taking `context` as an argument.
I believe the issue occurred because the middleware was not executed with the latest route information. Therefore, I have made a correction to use the route and from, which are callback arguments of beforeEach.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

