### PR TITLE
fix: expose `defineAsyncComponent` and `proxyRefs` at legacy runtime.

### DIFF
--- a/packages/bridge/src/runtime/capi.legacy.ts
+++ b/packages/bridge/src/runtime/capi.legacy.ts
@@ -57,6 +57,7 @@ export {
   watchPostEffect,
   watchSyncEffect,
   defineAsyncComponent,
+  proxyRefs
 } from 'vue'
 
 export { ref }
@@ -78,7 +79,6 @@ const warnOnce = (id, message) => {
 export const createApp = () => unsupported('`createApp` is not provided by Vue 2.7.')
 export const createRef = () => unsupported('`createRef` is not provided by Vue 2.7.')
 export const isRaw = () => unsupported('`isRaw` is not provided by Vue 2.7.')
-export const proxyRefs = () => unsupported('`proxyRefs` is not provided by Vue 2.7.')
 export const warn = () => unsupported('`warn` is not provided by Vue 2.7.')
 
 // Warn in case of having any imports from `@nuxtjs/composition-api`

--- a/packages/bridge/src/runtime/capi.legacy.ts
+++ b/packages/bridge/src/runtime/capi.legacy.ts
@@ -55,7 +55,8 @@ export {
   watch,
   watchEffect,
   watchPostEffect,
-  watchSyncEffect
+  watchSyncEffect,
+  defineAsyncComponent,
 } from 'vue'
 
 export { ref }
@@ -76,7 +77,6 @@ const warnOnce = (id, message) => {
 
 export const createApp = () => unsupported('`createApp` is not provided by Vue 2.7.')
 export const createRef = () => unsupported('`createRef` is not provided by Vue 2.7.')
-export const defineAsyncComponent = () => unsupported('`defineAsyncComponent` is not provided by Vue 2.7.')
 export const isRaw = () => unsupported('`isRaw` is not provided by Vue 2.7.')
 export const proxyRefs = () => unsupported('`proxyRefs` is not provided by Vue 2.7.')
 export const warn = () => unsupported('`warn` is not provided by Vue 2.7.')


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
`defineAsyncComponent` and `proxyRefs` are supported in Vue 2.7 and can be exposed without stubs. 
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

