### PR TITLE
fix: skip node for which definePageMeta does not exist

### DIFF
--- a/packages/bridge/src/page-meta/transform.ts
+++ b/packages/bridge/src/page-meta/transform.ts
@@ -166,6 +166,10 @@ export const PageMetaPlugin = createUnplugin(
                 }
               })
 
+              if (!contents) {
+                return
+              }
+
               s.prependLeft(exportDeclaration.start, contents)
 
               if (code.includes('__nuxt_page_meta')) {

--- a/packages/bridge/test/page-meta.test.ts
+++ b/packages/bridge/test/page-meta.test.ts
@@ -36,11 +36,17 @@ import { defineComponent as _defineComponent } from 'vue';
 export default /*#__PURE__*/_defineComponent({
   __name: 'redirect',
   setup: function setup(__props) {
-    const route = useRoute()
+    var route = useRoute()
     definePageMeta({
       middleware: ['redirect'],
       layout: 'custom'
     });
+
+    var obj = {
+      setup: {
+        test: 'test'
+      }
+    }
     return {
       __sfc: true
       };
@@ -54,8 +60,14 @@ export default /*#__PURE__*/_defineComponent({
   export default /*#__PURE__*/_defineComponent({
     ...__nuxt_page_meta,__name: 'redirect',
     setup: function setup(__props) {
-      const route = useRoute()
+      var route = useRoute()
       ;
+
+      var obj = {
+        setup: {
+          test: 'test'
+        }
+      }
       return {
         __sfc: true
         };
@@ -73,6 +85,12 @@ export default {
     definePageMeta({
       layout: 'custom'
     });
+
+    var obj = {
+      setup: {
+        test: 'test'
+      }
+    }
       return {
         __sfc: true,
         message: message
@@ -88,6 +106,12 @@ export default {
     setup: function setup(__props) {
       var message;
       ;
+
+      var obj = {
+        setup: {
+          test: 'test'
+        }
+      }
         return {
           __sfc: true,
           message: message
@@ -141,6 +165,11 @@ const _sfc_main = /* @__PURE__ */ _defineComponent({
     definePageMeta({
       middleware: ["redirect"]
     });
+    const obj = {
+      setup: {
+        test: "test"
+      }
+    }
     return { __sfc: true };
   }
 });`)).toMatchInlineSnapshot(`
@@ -153,6 +182,11 @@ const _sfc_main = /* @__PURE__ */ _defineComponent({
     ...__nuxt_page_meta,__name: "redirect",
     setup(__props) {
       ;
+      const obj = {
+        setup: {
+          test: "test"
+        }
+      }
       return { __sfc: true };
     }
   });"
@@ -169,6 +203,12 @@ const _sfc_main = /* @__PURE__ */ _defineComponent({
           definePageMeta({
             layout: 'custom'
           })
+
+          const obj = {
+            setup: {
+              test: 'test'
+            }
+          }
         
           return { __sfc: true,message }
         }
@@ -183,6 +223,12 @@ const _sfc_main = /* @__PURE__ */ _defineComponent({
                   let message
                 
                   
+
+                  const obj = {
+                    setup: {
+                      test: 'test'
+                    }
+                  }
                 
                   return { __sfc: true,message }
                 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
Fixes: https://github.com/nuxt/bridge/issues/1222
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
I expected to skip `setup` node that did not have `definePageMeta`, but I was not able to skip them, so I would like to fix that.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

