### PR TITLE
fix: match signature for nitro/nuxt `useRuntimeConfig`composables

### DIFF
--- a/packages/bridge/src/runtime/nuxt.ts
+++ b/packages/bridge/src/runtime/nuxt.ts
@@ -4,6 +4,7 @@ import { getCurrentInstance, reactive, onBeforeUnmount, watch, isRef } from 'vue
 import type { Ref } from 'vue'
 import type { CombinedVueInstance } from 'vue/types/vue'
 import type { MetaInfo } from 'vue-meta'
+import type { EventHandlerRequest, H3Event } from 'h3'
 import { defu } from 'defu'
 
 export interface Context {
@@ -132,7 +133,7 @@ export const useNuxtApp = (): NuxtAppCompat => {
 }
 
 // Runtime config helper
-export const useRuntimeConfig = () => {
+export const useRuntimeConfig = (_event?: H3Event<EventHandlerRequest>) => {
   const nuxtApp = useNuxtApp()
   if (nuxtApp._config) {
     return nuxtApp._config as RuntimeConfig


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
Fixes: https://github.com/nuxt/bridge/issues/1229
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This is caused by a mismatch in the sigunature of `useRuntimeConfig` in Nitro and Nuxt.
This is the same way as upstream.
https://github.com/nuxt/nuxt/pull/25440

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

