### PR TITLE
feat: add `open` option in `navigateTo` helper

### DIFF
--- a/packages/bridge/src/runtime/composables/router.ts
+++ b/packages/bridge/src/runtime/composables/router.ts
@@ -80,7 +80,7 @@ export const navigateTo = (to: RawLocation | undefined | null, options?: Navigat
   if (!to) {
     to = '/'
   }
-  const toPath = typeof to === 'string' ? to : (withQuery((to as Route).path || '/', to.query || {}) + (to.hash || ''))
+  const toPath = typeof to === 'string' ? to : 'path' in to ? resolveRouteObject(to) : useRouter().resolve(to).href
 
   const isExternal = options?.external || hasProtocol(toPath, { acceptRelative: true })
   if (isExternal && !options?.external) {
@@ -178,4 +178,11 @@ export const addRouteMiddleware: AddRouteMiddleware = (name: string | RouteMiddl
   } else {
     nuxtApp._middleware.named[name] = convertToLegacyMiddleware(middleware)
   }
+}
+
+/**
+ * @internal
+ */
+export function resolveRouteObject (to: Exclude<RawLocation, string>) {
+  return withQuery(to.path || '', to.query || {}) + (to.hash || '')
 }

--- a/packages/bridge/src/runtime/composables/router.ts
+++ b/packages/bridge/src/runtime/composables/router.ts
@@ -70,10 +70,29 @@ const isProcessingMiddleware = () => {
   return false
 }
 
+// Conditional types, either one or other
+type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never }
+type XOR<T, U> = (T | U) extends Object ? (Without<T, U> & U) | (Without<U, T> & T) : T | U
+
+export type OpenWindowFeatures = {
+  popup?: boolean
+  noopener?: boolean
+  noreferrer?: boolean
+} & XOR<{ width?: number }, { innerWidth?: number }>
+  & XOR<{ height?: number }, { innerHeight?: number }>
+  & XOR<{ left?: number }, { screenX?: number }>
+  & XOR<{ top?: number }, { screenY?: number }>
+
+export type OpenOptions = {
+  target: '_blank' | '_parent' | '_self' | '_top' | (string & {})
+  windowFeatures?: OpenWindowFeatures
+}
+
 export interface NavigateToOptions {
   replace?: boolean
-  redirectCode?: number,
+  redirectCode?: number
   external?: boolean
+  open?: OpenOptions
 }
 
 export const navigateTo = (to: RawLocation | undefined | null, options?: NavigateToOptions): Promise<void | Route | NavigationFailure | false> | false | void | RawLocation | Route => {
@@ -81,6 +100,19 @@ export const navigateTo = (to: RawLocation | undefined | null, options?: Navigat
     to = '/'
   }
   const toPath = typeof to === 'string' ? to : 'path' in to ? resolveRouteObject(to) : useRouter().resolve(to).href
+
+  // Early open handler
+  if (process.client && options?.open) {
+    const { target = '_blank', windowFeatures = {} } = options.open
+
+    const features = Object.entries(windowFeatures)
+      .filter(([_, value]) => value !== undefined)
+      .map(([feature, value]) => `${feature.toLowerCase()}=${value}`)
+      .join(', ')
+
+    open(toPath, target, features)
+    return Promise.resolve()
+  }
 
   const isExternal = options?.external || hasProtocol(toPath, { acceptRelative: true })
   if (isExternal && !options?.external) {

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -18,6 +18,10 @@
         </li>
       </ul>
     </section>
+
+    <button @click="handleClick">
+      open
+    </button>
   </div>
 </template>
 
@@ -28,6 +32,18 @@ const state = useState('test-state')
 state.value = '123'
 const updateState = () => { state.value = '456' }
 const serverBuild = useState('server-build', () => getCurrentInstance().proxy.$isServer)
+
+const handleClick = () => {
+  navigateTo('https://nuxt.com', {
+    open: {
+      target: '_blank',
+      windowFeatures: {
+        width: 500,
+        height: 500
+      }
+    }
+  })
+}
 </script>
 
 <style scoped>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
resolves: https://github.com/nuxt/bridge/issues/1158
resolves: https://github.com/nuxt/bridge/issues/1255
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
I would like port `open` option from upstream.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

