### PR TITLE
feat: port `useNuxtData` composable

### DIFF
--- a/packages/bridge/src/imports/presets.ts
+++ b/packages/bridge/src/imports/presets.ts
@@ -29,7 +29,7 @@ const granularAppPresets: InlinePreset[] = [
     from: '#app/composables/state'
   },
   {
-    imports: ['useLazyAsyncData', 'refreshNuxtData', 'clearNuxtData'],
+    imports: ['useLazyAsyncData', 'useNuxtData', 'refreshNuxtData', 'clearNuxtData'],
     from: '#app/composables/asyncData'
   },
   {

--- a/packages/bridge/src/runtime/composables/index.ts
+++ b/packages/bridge/src/runtime/composables/index.ts
@@ -1,4 +1,4 @@
-export { useLazyAsyncData, refreshNuxtData, clearNuxtData } from './asyncData'
+export { useLazyAsyncData, useNuxtData, refreshNuxtData, clearNuxtData } from './asyncData'
 export * from './component'
 export { useCookie } from './cookie'
 export { clearError, createError, isNuxtError, throwError, showError, useError } from './error'

--- a/playground/pages/async-data.vue
+++ b/playground/pages/async-data.vue
@@ -45,6 +45,8 @@ if (process.server) {
   })
 }
 
+const { data: usedNuxtData } = useLazyAsyncData('nuxtData', () => Promise.resolve('helloNuxtData'))
+const { data: accessNuxtData } = useNuxtData('nuxtData')
 </script>
 
 <template>
@@ -59,5 +61,6 @@ if (process.server) {
     <div>error3: {{ error3 }}</div>
     <div>clearableData-1: {{ clearableData1?.text }}</div>
     <div>clearableData-2: {{ clearableData2?.text }}</div>
+    <div>usedNuxtData: {{ usedNuxtData }}, nuxtData: {{ accessNuxtData }}</div>
   </div>
 </template>

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -75,6 +75,13 @@ describe('nuxt composables', () => {
     expect(html).not.toContain('clearableData-2: clearableData')
   })
 
+  it('should render text synced with useNuxtData', async () => {
+    const html = await $fetch('/async-data')
+    const expectedText = 'helloNuxtData'
+
+    expect(html).toContain(`usedNuxtData: ${expectedText}, nuxtData: ${expectedText}`)
+  })
+
   it('should render default value', async () => {
     const defaultValue = isV4 ? 'undefined' : 'null'
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/bridge/pull/1265

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

While wattanx working on the upstream port, needed `useNuxtData` to be ported,
so added it to the branch [(feat/default-data-and-error)](https://github.com/nuxt/bridge/tree/feat/default-data-and-error) he was working on.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

