### PR TITLE
fix: support `definePageMeta` in `defineNuxtComponent`

### DIFF
--- a/packages/bridge/src/page-meta/transform.ts
+++ b/packages/bridge/src/page-meta/transform.ts
@@ -202,7 +202,7 @@ function getObjectExpression (node: Node) {
 
   // ts and webpack
   if (node.type === 'CallExpression') {
-    if (node.callee.type === 'Identifier' && !node.callee.name.includes('defineComponent')) {
+    if (node.callee.type === 'Identifier' && !/define(Component|NuxtComponent)/.test(node.callee.name)) {
       return
     }
     if (node.arguments.length === 0) { return }

--- a/packages/bridge/test/page-meta.test.ts
+++ b/packages/bridge/test/page-meta.test.ts
@@ -166,6 +166,31 @@ export default {
         }));"
       `)
     })
+
+    it('defineNuxtComponent', async () => {
+      const input = `<script lang="ts">
+export default defineNuxtComponent({
+  setup() {
+    definePageMeta({
+      middleware: ['redirect'],
+    })
+
+    const route = useRoute()
+  }
+})
+</script>`
+      expect(await getResult(babelTransform(input))).toMatchInlineSnapshot(`
+        "const __nuxt_page_meta = {
+          middleware: ['redirect']
+        }
+        export default defineNuxtComponent({
+          ...__nuxt_page_meta,setup: function setup() {
+            ;
+            var route = useRoute();
+          }
+        });"
+      `)
+    })
   })
 
   describe('vite', () => {
@@ -278,6 +303,33 @@ export default {
         }
 
         })"
+      `)
+    })
+    it('defineNuxtComponent', async () => {
+      const input = `<script lang="ts">
+export default defineNuxtComponent({
+  setup() {
+    definePageMeta({
+      middleware: ['redirect'],
+    })
+
+    const route = useRoute()
+  }
+})
+</script>`
+      expect(await getResult(viteTransform(input))).toMatchInlineSnapshot(`
+        "
+        const __nuxt_page_meta = {
+          middleware: ['redirect']
+        }
+        const _sfc_main = defineNuxtComponent({
+          ...__nuxt_page_meta,setup() {
+            
+
+            const route = useRoute()
+          }
+        })
+        "
       `)
     })
   })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
In Nuxt 3 it is possible to use `definePageMeta` in the setup of defineNuxtComponent.
I would like to support the use of `definePageMeta` in `defineNuxtComponen`t in Nuxt Bridge as well as in Nuxt 3.

demo: https://stackblitz.com/edit/github-udoldr

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

