### PR TITLE
feat: support `import.meta.*` for vite

### DIFF
--- a/packages/bridge/src/vite/client.ts
+++ b/packages/bridge/src/vite/client.ts
@@ -44,6 +44,11 @@ export async function buildClient (ctx: ViteBuildContext) {
       'process.static': false,
       // use `process.client` instead. `process.browser` is deprecated
       'process.browser': true,
+      'import.meta.client': true,
+      'import.meta.server': false,
+      'import.meta.browser': true,
+      'import.meta.nitro': false,
+      'import.meta.prerender': false,
       'module.hot': false
     },
     cacheDir: resolve(ctx.nuxt.options.rootDir, 'node_modules/.cache/vite/client'),

--- a/packages/bridge/src/vite/server.ts
+++ b/packages/bridge/src/vite/server.ts
@@ -49,7 +49,10 @@ export async function buildServer (ctx: ViteBuildContext) {
       'process.client': false,
       'process.static': false,
       // use `process.client` instead. `process.browser` is deprecated
-      'process.browser': false
+      'process.browser': false,
+      'import.meta.server': true,
+      'import.meta.client': false,
+      'import.meta.browser': false
     },
     cacheDir: resolve(ctx.nuxt.options.rootDir, 'node_modules/.cache/vite/server'),
     resolve: {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
https://github.com/nuxt/bridge/issues/1295
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This PR supports `import.meta.*` in vite mode.
webpack 4 does not support `import.meta`, so we need to create a plugin.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

