### PR TITLE
fix: use legacy property `publicPath` for the assets url.

### DIFF
--- a/packages/bridge-schema/src/config/app.ts
+++ b/packages/bridge-schema/src/config/app.ts
@@ -39,6 +39,22 @@ export default defineUntypedSchema({
       $resolve: val => val || process.env.NUXT_APP_BUILD_ASSETS_DIR || '/_nuxt/'
     },
     /**
+     * An absolute URL to serve the public folder from (production-only).
+     *
+     * For example:
+     * @example
+     * ```ts
+     * export default defineNuxtConfig({
+     *   app: {
+     *     cdnURL: 'https://mycdn.org/'
+     *   }
+     * })
+     * ```
+     */
+    cdnURL: {
+      $resolve: async (val, get) => (await get('dev')) ? '' : (process.env.NUXT_APP_CDN_URL ?? val) || ''
+    },
+    /**
      * The folder name for the built site assets, relative to `baseURL` (or `cdnURL` if set).
      * @deprecated - use `buildAssetsDir` instead
      */

--- a/packages/bridge/src/nitro.ts
+++ b/packages/bridge/src/nitro.ts
@@ -24,10 +24,14 @@ export async function setupNitroBridge () {
   }
 
   // Handle legacy property name `assetsPath`
+  // @ts-expect-error `assetsPath` is legacy options
   nuxt.options.app.buildAssetsDir = nuxt.options.app.buildAssetsDir || nuxt.options.app.assetsPath
+  // @ts-expect-error `assetsPath` is legacy options
   nuxt.options.app.assetsPath = nuxt.options.app.buildAssetsDir
   nuxt.options.app.baseURL = nuxt.options.app.baseURL || (nuxt.options.app as any).basePath
   nuxt.options.app.cdnURL = nuxt.options.app.cdnURL || ''
+  // @ts-expect-error `publicPath` is legacy options
+  nuxt.options.build.publicPath = nuxt.options.app.cdnURL || nuxt.options.build.publicPath
 
   // Extract publicConfig and app
   const publicConfig = nuxt.options.publicRuntimeConfig


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
Fixes: https://github.com/nuxt/bridge/issues/635
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
In nuxt 2 the option to set the cdn url is `publicPath`.
https://v2.nuxt.com/docs/configuration-glossary/configuration-build/

The `app.cdnURL` is not used directly and must be set to `publicPath`.

Also, currently `NUXT_APP_CDN_URL` is not supported and must be set to `app.cdnURL`.
```ts
export default defineNuxtConfig({
  app: {
    cdnURL: process.env.NUXT_APP_CDN_URL
  }
})
```

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

