### PR TITLE
fix!: remove `resolve` option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,6 @@ jobs:
         builder: ['vite', 'webpack']
         transpile: ['transpile', 'no-transpile']
         compatibility: ['compatibility', 'no-compatibility']
-        resolve: ['resolve', 'no-resolve']
         typescript: ['isTSX', 'esbuild']
         vite-legacy: ['legacy', 'no-legacy']
         exclude:
@@ -94,8 +93,6 @@ jobs:
           - typescript: 'isTSX'
             builder: 'vite'
           - compatibility: 'no-compatibility'
-            builder: 'vite'
-          - resolve: 'no-resolve'
             builder: 'vite'
           - compatibility: 'no-compatibility'
             env: 'dev'
@@ -124,7 +121,6 @@ jobs:
           TEST_VITE_LEGACY: ${{ matrix.vite-legacy || 'legacy' }}
           TEST_TRANSPILE: ${{ matrix.transpile || 'transpile' }}
           TEST_COMPATIBILITY: ${{ matrix.compatibility || 'compatibility' }}
-          TEST_RESOLVE: ${{ matrix.resolve || 'resolve' }}
           TEST_TYPESCRIPT: ${{ matrix.typescript || 'isTSX' }}
           NODE_OPTIONS: --max-old-space-size=8192
 

--- a/packages/bridge/src/module.ts
+++ b/packages/bridge/src/module.ts
@@ -31,7 +31,6 @@ export default defineNuxtModule({
     compatibility: true,
     meta: null,
     typescript: true,
-    resolve: true,
     macros: false
   } as BridgeConfig,
   async setup (opts, nuxt) {
@@ -144,9 +143,9 @@ export default defineNuxtModule({
         })
       }
     }
-    if (opts.resolve) {
-      setupBetterResolve()
-    }
+
+    setupBetterResolve()
+
     if (opts.transpile) {
       setupTranspile()
     }

--- a/packages/bridge/types.d.ts
+++ b/packages/bridge/types.d.ts
@@ -43,7 +43,6 @@ export interface BridgeConfig {
   transpile: boolean
   compatibility: boolean
   postcss8: boolean
-  resolve: boolean
   typescript: boolean | {
     /**
      * @deprecated please use `esbuild` instead

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -8,7 +8,6 @@ const bridgeConfig = {
   vite: process.env.TEST_BUILDER !== 'webpack' ? { legacy: process.env.TEST_VITE_LEGACY !== 'no-legacy' } : false,
   transpile: process.env.TEST_TRANSPILE !== 'no-transpile',
   compatibility: process.env.TEST_COMPATIBILITY !== 'no-compatibility',
-  resolve: process.env.TEST_RESOLVE !== 'no-resolve',
   typescript: {
     isTSX: !process.env.TEST_TYPESCRIPT || process.env.TEST_TYPESCRIPT === 'isTSX',
     esbuild: process.env.TEST_TYPESCRIPT === 'esbuild'


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
The `resolve` option is a Webpack option that supports subpath exports.
Since this option hasn’t caused issues for a long time, I’d like to stop providing it as a configurable option.
(I was considering deprecating it, but I believe there are very few cases where it's actually being opted out of.)

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

