### PR TITLE
fix: prevent duplicate set-cookie headers

### DIFF
--- a/packages/bridge-schema/src/nuxt2context.ts
+++ b/packages/bridge-schema/src/nuxt2context.ts
@@ -48,6 +48,9 @@ export interface NuxtAppCompat {
   }
 
   provide: (name: string, value: any) => void
+
+  /** @internal */
+  _cookies?: Record<string, unknown>
 }
 
 export interface IncomingMessage extends HttpIncomingMessage {

--- a/packages/bridge/src/runtime/composables/cookie.ts
+++ b/packages/bridge/src/runtime/composables/cookie.ts
@@ -107,6 +107,16 @@ export function useCookie<T = string | null | undefined> (name: string, _opts?: 
     const nuxtApp = useNuxtApp()
     const writeFinalCookieValue = () => {
       if (opts.readonly || isEqual(cookie.value, cookies[name])) { return }
+      nuxtApp._cookies = nuxtApp._cookies || {}
+      if (name in nuxtApp._cookies) {
+        // do not append a second `set-cookie` header
+        if (isEqual(cookie.value, nuxtApp._cookies[name])) { return }
+        // warn in dev mode
+        if (process.dev) {
+          console.warn(`[nuxt] cookie \`${name}\` was previously set to \`${opts.encode(nuxtApp._cookies[name] as any)}\` and is being overridden to \`${opts.encode(cookie.value as any)}\`. This may cause unexpected issues.`)
+        }
+      }
+      nuxtApp._cookies[name] = cookie.value
       writeServerCookie(useRequestEvent(nuxtApp)!, name, cookie.value, opts as CookieOptions<any>)
     }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
Fixes: https://github.com/nuxt/bridge/issues/1272

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
When `useCookie` is called more than once, it results in multiple `set-cookie` headers.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

