### PR TITLE
chore: pin major versions for Nuxt and Unhead packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,7 +37,16 @@
       "matchPackageNames": [
         "nuxi",
         "/^@nuxt//"
-      ]
+      ],
+      "allowedVersions": "!/3$/"
+    },
+    {
+      "matchPackageNames": [
+        "@unhead/vue",
+        "@unhead/ssr",
+        "@unhead/schema"
+      ],
+      "allowedVersions": "!/1$/"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -46,7 +46,7 @@
         "@unhead/ssr",
         "@unhead/schema"
       ],
-      "allowedVersions": "!/1$/"
+      "allowedVersions": "<2"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -38,7 +38,7 @@
         "nuxi",
         "/^@nuxt//"
       ],
-      "allowedVersions": "!/3$/"
+      "allowedVersions": "<4"
     },
     {
       "matchPackageNames": [


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change
`@nuxt/kit` dropped compatibility with Nuxt 2 starting in v4, and `unhead` ended Vue 2 support in v2.
Therefore, we want to avoid bumping the major versions of these two packages.

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

