### PR TITLE
fix: support `type: module` in server build output

### DIFF
--- a/packages/bridge/src/nitro.ts
+++ b/packages/bridge/src/nitro.ts
@@ -251,9 +251,10 @@ export async function setupNitroBridge () {
   nuxt.hook('build:compiled', async ({ name }) => {
     if (nuxt.options._prepare) { return }
     if (name === 'server') {
-      const jsServerEntry = resolve(nuxt.options.buildDir, 'dist/server/server.js')
-      await fsp.writeFile(jsServerEntry.replace(/.js$/, '.cjs'), 'module.exports = require("./server.js")', 'utf8')
-      await fsp.writeFile(jsServerEntry.replace(/.js$/, '.mjs'), 'export { default } from "./server.cjs"', 'utf8')
+      const serverDir = resolve(nuxt.options.buildDir, 'dist/server')
+      await fsp.writeFile(resolve(serverDir, 'package.json'), JSON.stringify({ type: 'commonjs' }), 'utf8')
+      await fsp.writeFile(resolve(serverDir, 'server.cjs'), 'module.exports = require("./server.js")', 'utf8')
+      await fsp.writeFile(resolve(serverDir, 'server.mjs'), 'export { default } from "./server.cjs"', 'utf8')
     } else if (name === 'client' && nuxt.options.dev) {
       const manifest = await fsp.readFile(resolve(nuxt.options.buildDir, 'dist/server/client.manifest.json'), 'utf8')
       await fsp.writeFile(resolve(nuxt.options.buildDir, 'dist/server/client.manifest.mjs'), 'export default ' + JSON.stringify(normalizeWebpackManifest(JSON.parse(manifest)), null, 2), 'utf8')


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
Fixes: https://github.com/nuxt/bridge/issues/1144
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
When a project has `"type": "module"` in its root `package.json`, Node.js treats all `.js` files as ES modules by default. This causes issues with the server build output, which expects CommonJS semantics.

This PR adds a `package.json` file with `{ "type": "commonjs" }` to the `dist/server` directory during the build process. This ensures that `.js` files in the server build directory are correctly interpreted as CommonJS modules, regardless of the project's root `package.json` configuration.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

